### PR TITLE
Shell-escape tasks before passing them to capistrano

### DIFF
--- a/lib/pulsar/commands/main.rb
+++ b/lib/pulsar/commands/main.rb
@@ -1,3 +1,5 @@
+require "shellwords"
+
 module Pulsar
   class MainCommand < Clamp::Command
     include Pulsar::Helpers::Clamp
@@ -31,7 +33,7 @@ module Pulsar
             build_capfile(app, stage)
 
             unless skip_cap_run?
-              cap_args = [ tasks_list ].flatten.join(" ")
+              cap_args = [ tasks_list ].flatten.shelljoin
               run_capistrano(cap_args)
             end
           ensure


### PR DESCRIPTION
When I try to to use the `invoke` command I have the problem that the `COMMAND='some command'` is not being escaped before passed to capistrano.
Let's say I run:

``` bash
pulsar -v -l trace app env invoke COMMAND='uname -a'
```

Pulsar will eventually run:

``` bash
bundle exec cap CONFIG_PATH=/tmp/pulsar/conf-repo-2013-07-23-183838-s5061 --file /tmp/pulsar/capfile-2013-07-23-183838-s5061 invoke COMMAND=uname -a
```

which doesn't work and results in:

```
/usr/local/homebrew/Cellar/ruby/2.0.0-p247/lib/ruby/gems/2.0.0/gems/capistrano-2.15.5/lib/capistrano/cli/options.rb:154:in `parse_options!': invalid option: -a (OptionParser::InvalidOption)
    from /usr/local/homebrew/Cellar/ruby/2.0.0-p247/lib/ruby/gems/2.0.0/gems/capistrano-2.15.5/lib/capistrano/cli/options.rb:15:in `parse'
    from /usr/local/homebrew/Cellar/ruby/2.0.0-p247/lib/ruby/gems/2.0.0/gems/capistrano-2.15.5/lib/capistrano/cli/execute.rb:14:in `execute'
    from /usr/local/homebrew/Cellar/ruby/2.0.0-p247/lib/ruby/gems/2.0.0/gems/capistrano-2.15.5/bin/cap:4:in `<top (required)>'
    from /usr/local/opt/ruby/bin/cap:23:in `load'
    from /usr/local/opt/ruby/bin/cap:23:in `<main>'
```
