### PR TITLE
add more specific error message when app or stage config not found

### DIFF
--- a/lib/pulsar/helpers/clamp.rb
+++ b/lib/pulsar/helpers/clamp.rb
@@ -174,8 +174,8 @@ module Pulsar
         def validate(app, stage)
           app_path = config_app_path(app)
           stage_path = config_stage_path(app, stage)
-
-          raise(ArgumentError) unless File.exists?(app_path) && File.exists?(stage_path)
+          valid_paths = File.exists?(app_path) && File.exists?(stage_path)
+          raise(ArgumentError, "no pulsar config available for app=#{app}, stage=#{stage}") unless valid_paths
         end
       end
     end


### PR DESCRIPTION
With the current behavior, invoking pulsar with incorrect parameters leads to the following non-specific ArgumentError:

```
$ pulsar my_app my_stage my_cap_task
/Users/matt/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/pulsar-0.3.1/lib/pulsar/helpers/clamp.rb:178:in `validate': ArgumentError (ArgumentError)
```

or

```
$ pulsar my_stage my_cap_task
/Users/matt/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/pulsar-0.3.1/lib/pulsar/helpers/clamp.rb:178:in `validate': ArgumentError (ArgumentError)
```

With the PR, pulsar will complain in a more specific way which might help the user in constructing the proper pulsar invocation, particularly when they have the wrong # of parameters for the context, eg:

```
$ pulsar my_stage my_cap_task
/Users/matt/dev/pulsar/lib/pulsar/helpers/clamp.rb:178:in `validate': no pulsar config available for app=my_stage, stage=my_cap_task (ArgumentError)
```
