### PR TITLE
/tmp/pulsar is shared across users but not writable

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,13 +164,13 @@ You have three possibilities:
 
 * `-c` command line option
 * `PULSAR_CONF_REPO` environment variable
-* `~/.pulsar` configuration file
+* `~/.pulsar/config` configuration file
 
-The fastest way is probably the `.pulsar` hidden file inside your home directory:
+The fastest way is probably the `.pulsar/config` file inside your home directory:
 
 ```bash
 #
-# Inside ~/.pulsar
+# Inside ~/.pulsar/config
 #
 PULSAR_CONF_REPO="gh-user/pulsar-conf"
 

--- a/lib/pulsar.rb
+++ b/lib/pulsar.rb
@@ -5,6 +5,7 @@ module Pulsar
   require 'bundler'
   require 'colored'
   require 'shellwords'
+  require 'tmpdir'
   require 'pulsar/helpers/all'
   require 'pulsar/options/all'
   require 'pulsar/commands/all'

--- a/lib/pulsar/helpers/clamp.rb
+++ b/lib/pulsar/helpers/clamp.rb
@@ -43,7 +43,7 @@ module Pulsar
         end
 
         def create_tmp_dir
-          run_cmd("mkdir -p #{tmp_dir.shellescape}", verbose: verbose?)
+          run_cmd("mkdir -p #{tmp_path.shellescape}", verbose: verbose?)
         end
 
         def each_app

--- a/lib/pulsar/helpers/clamp.rb
+++ b/lib/pulsar/helpers/clamp.rb
@@ -43,7 +43,7 @@ module Pulsar
         end
 
         def create_tmp_dir
-          run_cmd("mkdir -p #{tmp_dir}", verbose: verbose?)
+          run_cmd("mkdir -p #{tmp_dir.shellescape}", verbose: verbose?)
         end
 
         def each_app

--- a/lib/pulsar/helpers/clamp.rb
+++ b/lib/pulsar/helpers/clamp.rb
@@ -34,7 +34,7 @@ module Pulsar
 
         def bundle_install
           cd(config_path, verbose: verbose?) do
-            run_cmd('bundle install --quiet', verbose: verbose?)
+            run_cmd("bundle install --quiet --path=#{bundle_path.shellescape}", verbose: verbose?)
           end
         end
 

--- a/lib/pulsar/helpers/clamp.rb
+++ b/lib/pulsar/helpers/clamp.rb
@@ -150,12 +150,11 @@ module Pulsar
         end
 
         def pulsar_configuration
-          conf_file = '.pulsar'
-          inside_app = File.join(application_path, conf_file) rescue nil
-          inside_home = File.join(Dir.home, conf_file) rescue nil
+          path_list = []
+          path_list << File.join(application_path, ".pulsar")  unless application_path.nil?
+          path_list << File.join(home_path, "config")
 
-          return inside_app if inside_app && File.file?(inside_app)
-          return inside_home if inside_home && File.file?(inside_home)
+          path_list.find { |path| File.file?(path) }
         end
 
         def remove_capfile

--- a/lib/pulsar/helpers/path.rb
+++ b/lib/pulsar/helpers/path.rb
@@ -2,11 +2,11 @@ module Pulsar
   module Helpers
     module Path
       def capfile_path
-        "#{tmp_dir}/pulsar-capfile-#{deploy_time}"
+        "#{tmp_path}/capfile-#{deploy_time}"
       end
 
       def config_path
-        "#{tmp_dir}/pulsar-conf-repo-#{setup_time}"
+        "#{tmp_path}/conf-repo-#{setup_time}"
       end
 
       def config_app_path(app)
@@ -41,8 +41,16 @@ module Pulsar
         clear_deploy_time
       end
 
+      def home_path
+        home_dir
+      end
+
       def bundle_path
-        File.join(home_dir, 'bundle')
+        File.join(home_path, 'bundle')
+      end
+
+      def tmp_path
+        File.join(home_path, 'tmp')
       end
 
       private

--- a/lib/pulsar/helpers/path.rb
+++ b/lib/pulsar/helpers/path.rb
@@ -41,6 +41,10 @@ module Pulsar
         clear_deploy_time
       end
 
+      def bundle_path
+        File.join(home_dir, 'bundle')
+      end
+
       private
 
       def clear_deploy_time

--- a/lib/pulsar/helpers/path.rb
+++ b/lib/pulsar/helpers/path.rb
@@ -2,11 +2,11 @@ module Pulsar
   module Helpers
     module Path
       def capfile_path
-        "#{tmp_dir}/capfile-#{deploy_time}"
+        "#{tmp_dir}/pulsar-capfile-#{deploy_time}"
       end
 
       def config_path
-        "#{tmp_dir}/conf-repo-#{setup_time}"
+        "#{tmp_dir}/pulsar-conf-repo-#{setup_time}"
       end
 
       def config_app_path(app)

--- a/lib/pulsar/options/conf_repo.rb
+++ b/lib/pulsar/options/conf_repo.rb
@@ -19,14 +19,10 @@ module Pulsar
                     'specify a branch for the configuration repository',
                     default: 'master'
 
-        base.option ['-d', '--tmp-dir'], 'TMP DIR',
-                    'a directory where to put the configuration repo to build capfile with',
-                    default: Dir.tmpdir
-
         base.option ['-h', '--home-dir'], 'HOME DIR',
                     'a directory to store per-user state',
                     environment_variable: 'PULSAR_HOME',
-                    default: File.join(Dir.home, '.pulsar.d')
+                    default: File.join(Dir.home, '.pulsar')
       end
 
       #

--- a/lib/pulsar/options/conf_repo.rb
+++ b/lib/pulsar/options/conf_repo.rb
@@ -21,7 +21,7 @@ module Pulsar
 
         base.option ['-d', '--tmp-dir'], 'TMP DIR',
                     'a directory where to put the configuration repo to build capfile with',
-                    default: '/tmp/pulsar'
+                    default: File.join(Dir.tmpdir, 'pulsar')
 
         base.option ['-h', '--home-dir'], 'HOME DIR',
                     'a directory to store per-user state',

--- a/lib/pulsar/options/conf_repo.rb
+++ b/lib/pulsar/options/conf_repo.rb
@@ -22,6 +22,11 @@ module Pulsar
         base.option ['-d', '--tmp-dir'], 'TMP DIR',
                     'a directory where to put the configuration repo to build capfile with',
                     default: '/tmp/pulsar'
+
+        base.option ['-h', '--home-dir'], 'HOME DIR',
+                    'a directory to store per-user state',
+                    environment_variable: 'PULSAR_HOME',
+                    default: File.join(Dir.home, '.pulsar.d')
       end
 
       #

--- a/lib/pulsar/options/conf_repo.rb
+++ b/lib/pulsar/options/conf_repo.rb
@@ -21,7 +21,7 @@ module Pulsar
 
         base.option ['-d', '--tmp-dir'], 'TMP DIR',
                     'a directory where to put the configuration repo to build capfile with',
-                    default: File.join(Dir.tmpdir, 'pulsar')
+                    default: Dir.tmpdir
 
         base.option ['-h', '--home-dir'], 'HOME DIR',
                     'a directory to store per-user state',

--- a/spec/pulsar/commands/init_spec.rb
+++ b/spec/pulsar/commands/init_spec.rb
@@ -4,6 +4,6 @@ describe Pulsar::InitCommand do
   let(:pulsar) { Pulsar::InitCommand.new("init") }
 
   it "copies over the configuration repo" do
-    expect{ pulsar.run(["#{tmp_path}/new-conf-repo"]) }.to change{ Dir.glob("#{tmp_path}/new-conf-repo").length }.by(1)
+    expect{ pulsar.run(["#{spec_tmp_path}/new-conf-repo"]) }.to change{ Dir.glob("#{spec_tmp_path}/new-conf-repo").length }.by(1)
   end
 end

--- a/spec/pulsar/commands/list_spec.rb
+++ b/spec/pulsar/commands/list_spec.rb
@@ -4,19 +4,19 @@ describe Pulsar::ListCommand do
   let(:pulsar) { Pulsar::ListCommand.new("list") }
 
   it "copies a the repo over to temp directory" do
-    expect{ pulsar.run(full_list_args + %w(--keep-repo)) }.to change{ Dir.glob("#{tmp_path}/conf-repo*").length }.by(1)
+    expect{ pulsar.run(full_list_args + %w(--keep-repo)) }.to change{ Dir.glob("#{tmp_path}/pulsar-conf-repo*").length }.by(1)
   end
 
   it "copies a the repo when there is a dir with same name" do
-    system("mkdir #{tmp_path}/conf-repo")
-    expect{ pulsar.run(full_list_args + %w(--keep-repo)) }.to change{ Dir.glob("#{tmp_path}/conf-repo*").length }.by(1)
+    system("mkdir #{tmp_path}/pulsar-conf-repo")
+    expect{ pulsar.run(full_list_args + %w(--keep-repo)) }.to change{ Dir.glob("#{tmp_path}/pulsar-conf-repo*").length }.by(1)
   end
 
   it "removes the temp directory even if it's raised an error" do
     allow_any_instance_of(Pulsar::ListCommand).to receive(:list_apps) { raise 'error' }
     pulsar.run(full_list_args) rescue nil
 
-    expect(Dir.glob("#{tmp_path}/conf-repo*")).to be_empty
+    expect(Dir.glob("#{tmp_path}/pulsar-conf-repo*")).to be_empty
   end
 
   it "lists configured apps and stages" do

--- a/spec/pulsar/commands/list_spec.rb
+++ b/spec/pulsar/commands/list_spec.rb
@@ -33,8 +33,8 @@ describe Pulsar::ListCommand do
   end
 
   context "dotfile options" do
-    it "reads configuration variables from .pulsar file in home" do
-      stub_dotfile(Dir.home, dummy_dotfile_options)
+    it "reads configuration variables from config file in home" do
+      stub_config(File.join(pulsar.home_path, 'config'), dummy_dotfile_options)
 
       pulsar.run(full_list_args)
 
@@ -42,7 +42,7 @@ describe Pulsar::ListCommand do
     end
 
     it "reads configuration variables from .pulsar file in rack app directory" do
-      stub_dotfile(dummy_rack_app_path, dummy_dotfile_options)
+      stub_config(File.join(dummy_rack_app_path, '.pulsar'), dummy_dotfile_options)
 
       FileUtils.cd(dummy_rack_app_path) do
         reload_main_command
@@ -54,7 +54,7 @@ describe Pulsar::ListCommand do
     end
 
     it "skips lines which cannot parse when reading .pulsar file" do
-      stub_dotfile(dummy_rack_app_path, [ "wrong_line", "# comment" ])
+      stub_config(File.join(dummy_rack_app_path, '.pulsar'), [ "wrong_line", "# comment" ])
 
       FileUtils.cd(dummy_rack_app_path) do
         reload_main_command
@@ -63,8 +63,8 @@ describe Pulsar::ListCommand do
       end
     end
 
-    it "falls back to .pulsar file in home directory if it's not in the rack app directory" do
-      stub_dotfile(Dir.home, dummy_dotfile_options)
+    it "falls back to config file in home directory if it's not in the rack app directory" do
+      stub_config(File.join(pulsar.home_path, 'config'), dummy_dotfile_options)
 
       allow(File).to receive(:file?).with("#{File.expand_path(dummy_rack_app_path)}/.pulsar").and_return(false)
 

--- a/spec/pulsar/commands/list_spec.rb
+++ b/spec/pulsar/commands/list_spec.rb
@@ -4,19 +4,19 @@ describe Pulsar::ListCommand do
   let(:pulsar) { Pulsar::ListCommand.new("list") }
 
   it "copies a the repo over to temp directory" do
-    expect{ pulsar.run(full_list_args + %w(--keep-repo)) }.to change{ Dir.glob("#{tmp_path}/pulsar-conf-repo*").length }.by(1)
+    expect{ pulsar.run(full_list_args + %w(--keep-repo)) }.to change{ Dir.glob("#{spec_tmp_path}/tmp/conf-repo*").length }.by(1)
   end
 
   it "copies a the repo when there is a dir with same name" do
-    system("mkdir #{tmp_path}/pulsar-conf-repo")
-    expect{ pulsar.run(full_list_args + %w(--keep-repo)) }.to change{ Dir.glob("#{tmp_path}/pulsar-conf-repo*").length }.by(1)
+    system("mkdir -p #{spec_tmp_path}/conf-repo")
+    expect{ pulsar.run(full_list_args + %w(--keep-repo)) }.to change{ Dir.glob("#{spec_tmp_path}/tmp/conf-repo*").length }.by(1)
   end
 
   it "removes the temp directory even if it's raised an error" do
     allow_any_instance_of(Pulsar::ListCommand).to receive(:list_apps) { raise 'error' }
     pulsar.run(full_list_args) rescue nil
 
-    expect(Dir.glob("#{tmp_path}/pulsar-conf-repo*")).to be_empty
+    expect(Dir.glob("#{spec_tmp_path}/tmp/conf-repo*")).to be_empty
   end
 
   it "lists configured apps and stages" do
@@ -91,15 +91,18 @@ describe Pulsar::ListCommand do
     end
   end
 
-  context "--tmp-dir option" do
+  context "--home-dir option" do
     it "is supported" do
-      expect{ pulsar.parse(base_args + %w(--tmp-dir dummy_tmp)) }.not_to raise_error
+      expect{ pulsar.parse(base_args + %w(--home-dir dummy_tmp)) }.not_to raise_error
     end
 
     it "creates the tmp directory if it doesn't exist" do
-      run_options = base_args + [ "--tmp-dir", tmp_path("tmp/non_existent") ]
+      Dir.mktmpdir do |dir|
+        run_options = base_args + [ "--home-dir", dir ]
 
-      expect{ pulsar.run(run_options) }.not_to raise_error
+        expect{ pulsar.run(run_options) }.not_to raise_error
+        expect( File.directory?(pulsar.tmp_path) ).to be(true)
+      end
     end
   end
 

--- a/spec/pulsar/commands/main_spec.rb
+++ b/spec/pulsar/commands/main_spec.rb
@@ -17,12 +17,12 @@ describe Pulsar::MainCommand do
     allow_any_instance_of(Pulsar::MainCommand).to receive(:run_capistrano) { raise 'error' }
     pulsar.run(base_args + [ "--tmp-dir", tmp_path, "--keep-capfile" ] + dummy_app) rescue nil
 
-    expect(Dir.glob("#{tmp_path}/conf-repo*")).to be_empty
+    expect(Dir.glob("#{tmp_path}/pulsar-conf-repo*")).to be_empty
   end
 
   it "copies a the repo when there is a dir with same name" do
-    system("mkdir #{tmp_path}/conf-repo")
-    expect{ pulsar.run(full_cap_args + %w(--keep-repo) + dummy_app) }.to change{ Dir.glob("#{tmp_path}/conf-repo*").length }.by(1)
+    system("mkdir #{tmp_path}/pulsar-conf-repo")
+    expect{ pulsar.run(full_cap_args + %w(--keep-repo) + dummy_app) }.to change{ Dir.glob("#{tmp_path}/pulsar-conf-repo*").length }.by(1)
   end
 
   it "uses dirname when inside a rack app directory" do

--- a/spec/pulsar/commands/main_spec.rb
+++ b/spec/pulsar/commands/main_spec.rb
@@ -15,14 +15,14 @@ describe Pulsar::MainCommand do
 
   it "removes the temp directory even if it's raised an error" do
     allow_any_instance_of(Pulsar::MainCommand).to receive(:run_capistrano) { raise 'error' }
-    pulsar.run(base_args + [ "--tmp-dir", tmp_path, "--keep-capfile" ] + dummy_app) rescue nil
+    pulsar.run(base_args + [ "--home-dir", spec_tmp_path, "--keep-capfile" ] + dummy_app) rescue nil
 
-    expect(Dir.glob("#{tmp_path}/pulsar-conf-repo*")).to be_empty
+    expect(Dir.glob("#{spec_tmp_path}/tmp/conf-repo*")).to be_empty
   end
 
   it "copies a the repo when there is a dir with same name" do
-    system("mkdir #{tmp_path}/pulsar-conf-repo")
-    expect{ pulsar.run(full_cap_args + %w(--keep-repo) + dummy_app) }.to change{ Dir.glob("#{tmp_path}/pulsar-conf-repo*").length }.by(1)
+    system("mkdir -p #{spec_tmp_path}/tmp/conf-repo")
+    expect{ pulsar.run(full_cap_args + %w(--keep-repo) + dummy_app) }.to change{ Dir.glob("#{spec_tmp_path}/tmp/conf-repo*").length }.by(1)
   end
 
   it "uses dirname when inside a rack app directory" do
@@ -235,15 +235,18 @@ describe Pulsar::MainCommand do
     end
   end
 
-  context "--tmp-dir option" do
+  context "--home-dir option" do
     it "is supported" do
-      expect{ pulsar.parse(base_args + %w(--tmp-dir dummy_tmp) + dummy_app) }.not_to raise_error
+      expect{ pulsar.parse(base_args + %w(--home-dir dummy_tmp) + dummy_app) }.not_to raise_error
     end
 
     it "creates the tmp directory if it doesn't exist" do
-      run_options = base_args + [ "--tmp-dir", tmp_path("tmp/non_existent"), "--skip-cap-run" ] + dummy_app
+      Dir.mktmpdir do |dir|
+        run_options = base_args + [ "--home-dir", dir, "--skip-cap-run" ] + dummy_app
 
-      expect{ pulsar.run(run_options) }.not_to raise_error
+        expect{ pulsar.run(run_options) }.not_to raise_error
+        expect( File.directory?(pulsar.tmp_path) ).to be(true)
+      end
     end
   end
 

--- a/spec/pulsar/commands/main_spec.rb
+++ b/spec/pulsar/commands/main_spec.rb
@@ -72,8 +72,8 @@ describe Pulsar::MainCommand do
   end
 
   context "dotfile options" do
-    it "reads configuration variables from .pulsar file in home" do
-      stub_dotfile(Dir.home, dummy_dotfile_options)
+    it "reads configuration variables from config file in home" do
+      stub_config(File.join(pulsar.home_path, 'config'), dummy_dotfile_options)
 
       pulsar.run(full_cap_args + dummy_app)
 
@@ -81,7 +81,7 @@ describe Pulsar::MainCommand do
     end
 
     it "reads configuration variables from .pulsar file in rack app directory" do
-      stub_dotfile(dummy_rack_app_path, dummy_dotfile_options)
+      stub_config(File.join(dummy_rack_app_path, '.pulsar'), dummy_dotfile_options)
 
       FileUtils.cd(dummy_rack_app_path) do
         reload_main_command
@@ -93,7 +93,7 @@ describe Pulsar::MainCommand do
     end
 
     it "skips lines which cannot parse when reading .pulsar file" do
-      stub_dotfile(dummy_rack_app_path, [ "wrong_line", "# comment"])
+      stub_config(File.join(dummy_rack_app_path, '.pulsar'), [ "wrong_line", "# comment"])
 
       FileUtils.cd(dummy_rack_app_path) do
         reload_main_command
@@ -103,7 +103,7 @@ describe Pulsar::MainCommand do
     end
 
     it "falls back to .pulsar file in home directory if it's not in the rack app directory" do
-      stub_dotfile(Dir.home, dummy_dotfile_options)
+      stub_config(File.join(spec_tmp_path, 'config'), dummy_dotfile_options)
 
       allow(File).to receive(:file?).with("#{File.expand_path(dummy_rack_app_path)}/.pulsar").and_return(false)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,8 +24,6 @@ RSpec.configure do |config|
   config.include OutputCapture
 
   config.before(:each) do
-    allow(Dir).to receive(:home).and_return("/fake/home")
-
     dummy_dotfile_options.keys.each do |variable|
       ENV.delete(variable.to_s)
     end

--- a/spec/support/modules/helpers.rb
+++ b/spec/support/modules/helpers.rb
@@ -4,7 +4,7 @@ module Helpers
   end
 
   def capfile_count
-    Dir.glob("#{tmp_path}/capfile-*").length
+    Dir.glob("#{tmp_path}/pulsar-capfile-*").length
   end
 
   def dummy_app(stage = :production)
@@ -36,7 +36,7 @@ module Helpers
   end
 
   def latest_capfile
-    capfile = File.open(Dir.glob("#{tmp_path}/capfile-*").first)
+    capfile = File.open(Dir.glob("#{tmp_path}/pulsar-capfile-*").first)
     content = capfile.read
     capfile.close
 

--- a/spec/support/modules/helpers.rb
+++ b/spec/support/modules/helpers.rb
@@ -54,8 +54,8 @@ module Helpers
     allow_any_instance_of(Pulsar::MainCommand).to receive(:bundle_install)
   end
 
-  def stub_dotfile(path, options)
-    extended_path = "#{File.expand_path(path)}/.pulsar"
+  def stub_config(path, options)
+    extended_path = File.expand_path(path)
     dotfile_lines = []
 
     options.each do |option, value|
@@ -66,7 +66,8 @@ module Helpers
       end
     end
 
-    allow(File).to receive(:file?).and_return(true)
+    allow(File).to receive(:file?).and_return(false)
+    allow(File).to receive(:file?).with(extended_path).and_return(true)
     allow(File).to receive(:readlines).with(extended_path).and_return(dotfile_lines)
   end
 

--- a/spec/support/modules/helpers.rb
+++ b/spec/support/modules/helpers.rb
@@ -4,7 +4,7 @@ module Helpers
   end
 
   def capfile_count
-    Dir.glob("#{tmp_path}/pulsar-capfile-*").length
+    Dir.glob("#{spec_tmp_path}/tmp/capfile-*").length
   end
 
   def dummy_app(stage = :production)
@@ -28,15 +28,15 @@ module Helpers
   end
 
   def full_cap_args
-    base_args + [ "--tmp-dir", tmp_path, "--keep-capfile", "--skip-cap-run" ]
+    base_args + [ "--home-dir", spec_tmp_path, "--keep-capfile", "--skip-cap-run" ]
   end
 
   def full_list_args
-    base_args + [ "--tmp-dir", tmp_path, "--keep-capfile" ]
+    base_args + [ "--home-dir", spec_tmp_path, "--keep-capfile" ]
   end
 
   def latest_capfile
-    capfile = File.open(Dir.glob("#{tmp_path}/pulsar-capfile-*").first)
+    capfile = File.open(Dir.glob("#{spec_tmp_path}/tmp/capfile-*").first)
     content = capfile.read
     capfile.close
 
@@ -70,11 +70,7 @@ module Helpers
     allow(File).to receive(:readlines).with(extended_path).and_return(dotfile_lines)
   end
 
-  def tmp_dir
-    "tmp"
-  end
-
-  def tmp_path(dir=tmp_dir)
-    File.join(File.dirname(__FILE__), "..", dir)
+  def spec_tmp_path
+    File.join(File.dirname(__FILE__), "..", "tmp")
   end
 end


### PR DESCRIPTION
If user `foo` is running *pulsar*, then it will create `/tmp/pulsar` owned by him and not writable by others. If then user `bar` runs *pulsar* he's not able to write to the directory:
```
fatal: could not create work tree dir '/tmp/pulsar/conf-repo-xxx'.: Permission denied
```

I understand this can be worked around by passing a specific `--tmp-dir`. But I think it would be great if this worked out of the box.

What do you think about making `/tmp/pulsar` world writable?