### PR TITLE
Add deploy command

### DIFF
--- a/lib/pulsar.rb
+++ b/lib/pulsar.rb
@@ -9,6 +9,7 @@ module Pulsar
   require 'fileutils'
 
   require 'pulsar/interactors/cleanup'
+  require 'pulsar/interactors/create_run_dirs'
   require 'pulsar/interactors/add_applications'
   require 'pulsar/interactors/clone_repository'
   require 'pulsar/interactors/copy_initial_repository'

--- a/lib/pulsar.rb
+++ b/lib/pulsar.rb
@@ -17,6 +17,7 @@ module Pulsar
   require 'pulsar/interactors/identify_repository_location'
   require 'pulsar/interactors/create_capfile'
   require 'pulsar/interactors/create_deploy_file'
+  require 'pulsar/interactors/copy_environment_file'
 
   require 'pulsar/organizers/list'
   require 'pulsar/organizers/install'

--- a/lib/pulsar.rb
+++ b/lib/pulsar.rb
@@ -18,6 +18,8 @@ module Pulsar
   require 'pulsar/interactors/create_capfile'
   require 'pulsar/interactors/create_deploy_file'
   require 'pulsar/interactors/copy_environment_file'
+  require 'pulsar/interactors/run_bundle_install'
+  require 'pulsar/interactors/run_capistrano'
 
   require 'pulsar/organizers/list'
   require 'pulsar/organizers/install'

--- a/lib/pulsar.rb
+++ b/lib/pulsar.rb
@@ -14,9 +14,11 @@ module Pulsar
   require 'pulsar/interactors/copy_initial_repository'
   require 'pulsar/interactors/identify_repository_type'
   require 'pulsar/interactors/identify_repository_location'
+  require 'pulsar/interactors/create_capfile'
 
   require 'pulsar/organizers/list'
   require 'pulsar/organizers/install'
+  require 'pulsar/organizers/deploy'
 
   require 'pulsar/constants'
   require 'pulsar/cli'

--- a/lib/pulsar.rb
+++ b/lib/pulsar.rb
@@ -16,6 +16,7 @@ module Pulsar
   require 'pulsar/interactors/identify_repository_type'
   require 'pulsar/interactors/identify_repository_location'
   require 'pulsar/interactors/create_capfile'
+  require 'pulsar/interactors/create_deploy_file'
 
   require 'pulsar/organizers/list'
   require 'pulsar/organizers/install'

--- a/lib/pulsar/cli.rb
+++ b/lib/pulsar/cli.rb
@@ -31,27 +31,27 @@ module Pulsar
       if result.success?
         puts result.applications
       else
-        puts 'Failed to list application and stages.'
+        puts 'Failed to list application and environments.'
       end
     end
 
-    desc 'deploy APPLICATION STAGE', 'Run Capistrano to deploy APPLICATION on STAGE'
+    desc 'deploy APPLICATION ENVIRONMENT', 'Run Capistrano to deploy APPLICATION on ENVIRONMENT'
     long_desc <<-LONGDESC
-      `pulsar deploy APPLICATION STAGE` will generate the configuration for the
-      specified APPLICATION on STAGE from the configuration repo and run
+      `pulsar deploy APPLICATION ENVIRONMENT` will generate the configuration for the
+      specified APPLICATION on ENVIRONMENT from the configuration repo and run
       Capistrano on it.
     LONGDESC
     option :conf_repo, aliases: '-c'
-    def deploy(application, stage)
+    def deploy(application, environment)
       result = Pulsar::Deploy.call(
         repository: load_option_or_env!(:conf_repo),
-        application: application, stage: stage
+        application: application, environment: environment
       )
 
       if result.success?
         puts result.applications
       else
-        puts 'Failed to list application and stages.'
+        puts 'Failed to list application and environments.'
       end
     end
 

--- a/lib/pulsar/cli.rb
+++ b/lib/pulsar/cli.rb
@@ -43,15 +43,16 @@ module Pulsar
     LONGDESC
     option :conf_repo, aliases: '-c'
     def deploy(application, environment)
+      load_config
       result = Pulsar::Deploy.call(
         repository: load_option_or_env!(:conf_repo),
         application: application, environment: environment
       )
 
       if result.success?
-        puts result.applications
+        puts "Deployed #{application} on #{environment}!"
       else
-        puts 'Failed to list application and environments.'
+        puts "Failed to deploy #{application} on #{environment}."
       end
     end
 

--- a/lib/pulsar/cli.rb
+++ b/lib/pulsar/cli.rb
@@ -42,8 +42,17 @@ module Pulsar
       Capistrano on it.
     LONGDESC
     option :conf_repo, aliases: '-c'
-    def deploy(_application, _stage)
-      load_option_or_env!(:conf_repo)
+    def deploy(application, stage)
+      result = Pulsar::Deploy.call(
+        repository: load_option_or_env!(:conf_repo),
+        application: application, stage: stage
+      )
+
+      if result.success?
+        puts result.applications
+      else
+        puts 'Failed to list application and stages.'
+      end
     end
 
     private

--- a/lib/pulsar/interactors/add_applications.rb
+++ b/lib/pulsar/interactors/add_applications.rb
@@ -29,7 +29,7 @@ module Pulsar
 
     def each_application_path
       Dir["#{context.config_path}/apps/*"].sort.each do |app|
-        next if File.basename(app, '.rb') == 'defaults' ||
+        next if File.basename(app, '.rb') == 'deploy' ||
                 File.basename(app) == 'Capfile'
 
         yield(app)
@@ -41,7 +41,7 @@ module Pulsar
         File.basename(file, '.rb')
       end
       stage_files.reject do |stage|
-        %w(defaults Capfile).include?(stage)
+        %w(deploy Capfile).include?(stage)
       end.join(', ')
     end
   end

--- a/lib/pulsar/interactors/add_applications.rb
+++ b/lib/pulsar/interactors/add_applications.rb
@@ -29,7 +29,8 @@ module Pulsar
 
     def each_application_path
       Dir["#{context.config_path}/apps/*"].sort.each do |app|
-        next if File.basename(app, '.rb') == 'defaults'
+        next if File.basename(app, '.rb') == 'defaults' ||
+                File.basename(app) == 'Capfile'
 
         yield(app)
       end
@@ -39,7 +40,9 @@ module Pulsar
       stage_files = Dir["#{app}/*.rb"].sort.map do |file|
         File.basename(file, '.rb')
       end
-      stage_files.reject { |stage| stage == 'defaults' }.join(', ')
+      stage_files.reject do |stage|
+        %w(defaults Capfile).include?(stage)
+      end.join(', ')
     end
   end
 end

--- a/lib/pulsar/interactors/cleanup.rb
+++ b/lib/pulsar/interactors/cleanup.rb
@@ -3,7 +3,7 @@ module Pulsar
     include Interactor
 
     def call
-      FileUtils.rm_rf(context.config_path)
+      FileUtils.rm_rf(context.run_path)
     end
   end
 end

--- a/lib/pulsar/interactors/clone_repository.rb
+++ b/lib/pulsar/interactors/clone_repository.rb
@@ -2,7 +2,7 @@ module Pulsar
   class CloneRepository
     include Interactor
 
-    before :validate_input!, :prepare_context
+    before :validate_input!
 
     def call
       case context.repository_type
@@ -14,19 +14,12 @@ module Pulsar
       context.fail!
     end
 
-    def rollback
-      FileUtils.rm_rf(context.config_path)
-    end
-
     private
 
-    def prepare_context
-      FileUtils.mkdir_p(PULSAR_TMP)
-      context.config_path = "#{PULSAR_TMP}/conf-#{Time.now.to_f}"
-    end
-
     def validate_input!
-      context.fail! if context.repository.nil? || context.repository_type.nil?
+      context.fail! if context.config_path.nil? ||
+                       context.repository.nil? ||
+                       context.repository_type.nil?
     end
 
     def clone_git_repository
@@ -51,7 +44,7 @@ module Pulsar
     end
 
     def copy_local_folder
-      FileUtils.cp_r(context.repository, context.config_path)
+      FileUtils.cp_r("#{context.repository}/.", context.config_path)
     end
   end
 end

--- a/lib/pulsar/interactors/copy_environment_file.rb
+++ b/lib/pulsar/interactors/copy_environment_file.rb
@@ -1,0 +1,30 @@
+module Pulsar
+  class CopyEnvironmentFile
+    include Interactor
+
+    before :validate_input!, :prepare_context
+
+    def call
+      env_file = "#{context.config_path}/apps/#{context.application}/#{context.environment}.rb"
+
+      FileUtils.mkdir_p(context.cap_deploy_path)
+      FileUtils.cp(env_file, context.environment_file_path)
+    rescue
+      context.fail!
+    end
+
+    private
+
+    def prepare_context
+      context.cap_deploy_path = "#{context.cap_path}/config/deploy"
+      context.environment_file_path = "#{context.cap_deploy_path}/#{context.environment}.rb"
+    end
+
+    def validate_input!
+      context.fail! if context.config_path.nil? ||
+                       context.cap_path.nil? ||
+                       context.application.nil? ||
+                       context.environment.nil?
+    end
+  end
+end

--- a/lib/pulsar/interactors/create_capfile.rb
+++ b/lib/pulsar/interactors/create_capfile.rb
@@ -1,0 +1,34 @@
+module Pulsar
+  class CreateCapfile
+    include Interactor
+
+    before :validate_input!, :prepare_context
+
+    def call
+      default_capfile = "#{context.config_path}/apps/Capfile"
+      app_capfile     = "#{context.config_path}/apps/#{context.application}/Capfile"
+      import_tasks    = "Dir.glob(\"**/*.rake\").each { |r| import r }"
+
+      FileUtils.mkdir_p(context.capistrano_path)
+      FileUtils.touch(context.capfile_path)
+      Rake.sh("cat #{default_capfile} >> #{context.capfile_path}") if File.exist?(default_capfile)
+      Rake.sh("cat #{app_capfile}     >> #{context.capfile_path}") if File.exist?(app_capfile)
+      Rake.sh("echo '#{import_tasks}' >> #{context.capfile_path}")
+    rescue
+      context.fail!
+    end
+
+    private
+
+    def prepare_context
+      context.capistrano_path = "#{PULSAR_TMP}/cap-#{Time.now.to_f}"
+      context.capfile_path = "#{context.capistrano_path}/Capfile"
+    end
+
+    def validate_input!
+      context.fail! if context.config_path.nil? ||
+                       context.application.nil? ||
+                       context.environment.nil?
+    end
+  end
+end

--- a/lib/pulsar/interactors/create_capfile.rb
+++ b/lib/pulsar/interactors/create_capfile.rb
@@ -7,7 +7,7 @@ module Pulsar
     def call
       default_capfile = "#{context.config_path}/apps/Capfile"
       app_capfile     = "#{context.config_path}/apps/#{context.application}/Capfile"
-      import_tasks    = "Dir.glob(\"**/*.rake\").each { |r| import r }"
+      import_tasks    = "Dir.glob(\"#{context.config_path}/recipes/**/*.rake\").each { |r| import r }"
 
       FileUtils.touch(context.capfile_path)
       Rake.sh("cat #{default_capfile} >> #{context.capfile_path}") if File.exist?(default_capfile)

--- a/lib/pulsar/interactors/create_capfile.rb
+++ b/lib/pulsar/interactors/create_capfile.rb
@@ -9,7 +9,6 @@ module Pulsar
       app_capfile     = "#{context.config_path}/apps/#{context.application}/Capfile"
       import_tasks    = "Dir.glob(\"**/*.rake\").each { |r| import r }"
 
-      FileUtils.mkdir_p(context.capistrano_path)
       FileUtils.touch(context.capfile_path)
       Rake.sh("cat #{default_capfile} >> #{context.capfile_path}") if File.exist?(default_capfile)
       Rake.sh("cat #{app_capfile}     >> #{context.capfile_path}") if File.exist?(app_capfile)
@@ -21,12 +20,12 @@ module Pulsar
     private
 
     def prepare_context
-      context.capistrano_path = "#{PULSAR_TMP}/cap-#{Time.now.to_f}"
-      context.capfile_path = "#{context.capistrano_path}/Capfile"
+      context.capfile_path = "#{context.cap_path}/Capfile"
     end
 
     def validate_input!
       context.fail! if context.config_path.nil? ||
+                       context.cap_path.nil? ||
                        context.application.nil? ||
                        context.environment.nil?
     end

--- a/lib/pulsar/interactors/create_capfile.rb
+++ b/lib/pulsar/interactors/create_capfile.rb
@@ -26,8 +26,7 @@ module Pulsar
     def validate_input!
       context.fail! if context.config_path.nil? ||
                        context.cap_path.nil? ||
-                       context.application.nil? ||
-                       context.environment.nil?
+                       context.application.nil?
     end
   end
 end

--- a/lib/pulsar/interactors/create_deploy_file.rb
+++ b/lib/pulsar/interactors/create_deploy_file.rb
@@ -1,0 +1,32 @@
+module Pulsar
+  class CreateDeployFile
+    include Interactor
+
+    before :validate_input!, :prepare_context
+
+    def call
+      default_deploy = "#{context.config_path}/apps/deploy.rb"
+      app_deploy     = "#{context.config_path}/apps/#{context.application}/deploy.rb"
+
+      FileUtils.mkdir_p(context.cap_config_path)
+      FileUtils.touch(context.deploy_file_path)
+      Rake.sh("cat #{default_deploy} >> #{context.deploy_file_path}") if File.exist?(default_deploy)
+      Rake.sh("cat #{app_deploy}     >> #{context.deploy_file_path}") if File.exist?(app_deploy)
+    rescue
+      context.fail!
+    end
+
+    private
+
+    def prepare_context
+      context.cap_config_path = "#{context.cap_path}/config"
+      context.deploy_file_path = "#{context.cap_config_path}/deploy.rb"
+    end
+
+    def validate_input!
+      context.fail! if context.config_path.nil? ||
+                       context.cap_path.nil? ||
+                       context.application.nil?
+    end
+  end
+end

--- a/lib/pulsar/interactors/create_run_dirs.rb
+++ b/lib/pulsar/interactors/create_run_dirs.rb
@@ -1,0 +1,19 @@
+module Pulsar
+  class CreateRunDirs
+    include Interactor
+
+    def call
+      context.timestamp = Time.now.to_f
+      context.run_path = "#{PULSAR_TMP}/run-#{context.timestamp}"
+      context.config_path = "#{context.run_path}/conf"
+      context.cap_path = "#{context.run_path}/cap"
+
+      FileUtils.mkdir_p(context.config_path)
+      FileUtils.mkdir_p(context.cap_path)
+    end
+
+    def rollback
+      FileUtils.rm_rf(context.run_path)
+    end
+  end
+end

--- a/lib/pulsar/interactors/create_run_dirs.rb
+++ b/lib/pulsar/interactors/create_run_dirs.rb
@@ -4,10 +4,12 @@ module Pulsar
 
     def call
       context.timestamp = Time.now.to_f
+      context.bundle_path = "#{PULSAR_HOME}/bundle"
       context.run_path = "#{PULSAR_TMP}/run-#{context.timestamp}"
       context.config_path = "#{context.run_path}/conf"
       context.cap_path = "#{context.run_path}/cap"
 
+      FileUtils.mkdir_p(context.bundle_path)
       FileUtils.mkdir_p(context.config_path)
       FileUtils.mkdir_p(context.cap_path)
     end

--- a/lib/pulsar/interactors/create_run_dirs.rb
+++ b/lib/pulsar/interactors/create_run_dirs.rb
@@ -3,11 +3,11 @@ module Pulsar
     include Interactor
 
     def call
-      context.timestamp = Time.now.to_f
+      context.timestamp   = Time.now.to_f
       context.bundle_path = "#{PULSAR_HOME}/bundle"
-      context.run_path = "#{PULSAR_TMP}/run-#{context.timestamp}"
+      context.run_path    = "#{PULSAR_TMP}/run-#{context.timestamp}"
       context.config_path = "#{context.run_path}/conf"
-      context.cap_path = "#{context.run_path}/cap"
+      context.cap_path    = "#{context.run_path}/cap"
 
       FileUtils.mkdir_p(context.bundle_path)
       FileUtils.mkdir_p(context.config_path)

--- a/lib/pulsar/interactors/run_bundle_install.rb
+++ b/lib/pulsar/interactors/run_bundle_install.rb
@@ -1,0 +1,23 @@
+module Pulsar
+  class RunBundleInstall
+    include Interactor
+
+    before :validate_input!
+
+    def call
+      gemfile_env = "BUNDLE_GEMFILE=#{context.config_path}/Gemfile"
+      bundle_env  = "BUNDLE_PATH=#{context.bundle_path}"
+
+      system("#{gemfile_env} #{bundle_env} bundle install")
+    rescue
+      context.fail!
+    end
+
+    private
+
+    def validate_input!
+      context.fail! if context.config_path.nil? ||
+                       context.bundle_path.nil?
+    end
+  end
+end

--- a/lib/pulsar/interactors/run_bundle_install.rb
+++ b/lib/pulsar/interactors/run_bundle_install.rb
@@ -7,8 +7,9 @@ module Pulsar
     def call
       gemfile_env = "BUNDLE_GEMFILE=#{context.config_path}/Gemfile"
       bundle_env  = "BUNDLE_PATH=#{context.bundle_path}"
+      out_redir   = ENV['DRY_RUN'] ? '> /dev/null 2>&1' : nil
 
-      system("#{gemfile_env} #{bundle_env} bundle install")
+      context.fail! unless system("#{gemfile_env} #{bundle_env} bundle install#{out_redir}")
     rescue
       context.fail!
     end

--- a/lib/pulsar/interactors/run_capistrano.rb
+++ b/lib/pulsar/interactors/run_capistrano.rb
@@ -8,8 +8,11 @@ module Pulsar
       Dir.chdir(context.cap_path) do
         gemfile_env = "BUNDLE_GEMFILE=#{context.config_path}/Gemfile"
         bundle_env  = "BUNDLE_PATH=#{context.bundle_path}"
+        cap_opts    = ENV['DRY_RUN'] ? '--dry-run ' : nil
+        out_redir   = ENV['DRY_RUN'] ? '> /dev/null 2>&1' : nil
+        cap_cmd     = "bundle exec cap #{cap_opts}#{context.environment} deploy"
 
-        system("#{gemfile_env} #{bundle_env} bundle exec cap #{'--dry-run ' if ENV['CAP_DRY_RUN']}#{context.environment} deploy")
+        context.fail! unless system("#{gemfile_env} #{bundle_env} #{cap_cmd}#{out_redir}")
       end
     rescue
       context.fail!

--- a/lib/pulsar/interactors/run_capistrano.rb
+++ b/lib/pulsar/interactors/run_capistrano.rb
@@ -9,7 +9,7 @@ module Pulsar
         gemfile_env = "BUNDLE_GEMFILE=#{context.config_path}/Gemfile"
         bundle_env  = "BUNDLE_PATH=#{context.bundle_path}"
 
-        system("#{gemfile_env} #{bundle_env} bundle exec cap #{context.environment} deploy")
+        system("#{gemfile_env} #{bundle_env} bundle exec cap #{'--dry-run ' if ENV['CAP_DRY_RUN']}#{context.environment} deploy")
       end
     rescue
       context.fail!

--- a/lib/pulsar/interactors/run_capistrano.rb
+++ b/lib/pulsar/interactors/run_capistrano.rb
@@ -1,0 +1,27 @@
+module Pulsar
+  class RunCapistrano
+    include Interactor
+
+    before :validate_input!
+
+    def call
+      Dir.chdir(context.cap_path) do
+        gemfile_env = "BUNDLE_GEMFILE=#{context.config_path}/Gemfile"
+        bundle_env  = "BUNDLE_PATH=#{context.bundle_path}"
+
+        system("#{gemfile_env} #{bundle_env} bundle exec cap #{context.environment} deploy")
+      end
+    rescue
+      context.fail!
+    end
+
+    private
+
+    def validate_input!
+      context.fail! if context.cap_path.nil? ||
+                       context.config_path.nil? ||
+                       context.bundle_path.nil? ||
+                       context.environment.nil?
+    end
+  end
+end

--- a/lib/pulsar/organizers/deploy.rb
+++ b/lib/pulsar/organizers/deploy.rb
@@ -4,6 +4,6 @@ module Pulsar
 
     organize IdentifyRepositoryLocation, IdentifyRepositoryType,
              CreateRunDirs, CloneRepository, CreateCapfile, CreateDeployFile,
-             Cleanup
+             CopyEnvironmentFile, Cleanup
   end
 end

--- a/lib/pulsar/organizers/deploy.rb
+++ b/lib/pulsar/organizers/deploy.rb
@@ -3,6 +3,6 @@ module Pulsar
     include Interactor::Organizer
 
     organize IdentifyRepositoryLocation, IdentifyRepositoryType,
-             CloneRepository, CreateCapfile, Cleanup
+             CreateRunDirs, CloneRepository, CreateCapfile, Cleanup
   end
 end

--- a/lib/pulsar/organizers/deploy.rb
+++ b/lib/pulsar/organizers/deploy.rb
@@ -1,0 +1,8 @@
+module Pulsar
+  class Deploy
+    include Interactor::Organizer
+
+    organize IdentifyRepositoryLocation, IdentifyRepositoryType,
+             CloneRepository, CreateCapfile, Cleanup
+  end
+end

--- a/lib/pulsar/organizers/deploy.rb
+++ b/lib/pulsar/organizers/deploy.rb
@@ -2,8 +2,15 @@ module Pulsar
   class Deploy
     include Interactor::Organizer
 
-    organize IdentifyRepositoryLocation, IdentifyRepositoryType,
-             CreateRunDirs, CloneRepository, CreateCapfile, CreateDeployFile,
-             CopyEnvironmentFile, RunBundleInstall, RunCapistrano, Cleanup
+    organize IdentifyRepositoryLocation,
+             IdentifyRepositoryType,
+             CreateRunDirs,
+             CloneRepository,
+             CreateCapfile,
+             CreateDeployFile,
+             CopyEnvironmentFile,
+             RunBundleInstall,
+             RunCapistrano,
+             Cleanup
   end
 end

--- a/lib/pulsar/organizers/deploy.rb
+++ b/lib/pulsar/organizers/deploy.rb
@@ -4,6 +4,6 @@ module Pulsar
 
     organize IdentifyRepositoryLocation, IdentifyRepositoryType,
              CreateRunDirs, CloneRepository, CreateCapfile, CreateDeployFile,
-             CopyEnvironmentFile, Cleanup
+             CopyEnvironmentFile, RunBundleInstall, RunCapistrano, Cleanup
   end
 end

--- a/lib/pulsar/organizers/deploy.rb
+++ b/lib/pulsar/organizers/deploy.rb
@@ -3,6 +3,7 @@ module Pulsar
     include Interactor::Organizer
 
     organize IdentifyRepositoryLocation, IdentifyRepositoryType,
-             CreateRunDirs, CloneRepository, CreateCapfile, Cleanup
+             CreateRunDirs, CloneRepository, CreateCapfile, CreateDeployFile,
+             Cleanup
   end
 end

--- a/lib/pulsar/organizers/list.rb
+++ b/lib/pulsar/organizers/list.rb
@@ -2,7 +2,11 @@ module Pulsar
   class List
     include Interactor::Organizer
 
-    organize IdentifyRepositoryLocation, IdentifyRepositoryType,
-             CreateRunDirs, CloneRepository, AddApplications, Cleanup
+    organize IdentifyRepositoryLocation,
+             IdentifyRepositoryType,
+             CreateRunDirs,
+             CloneRepository,
+             AddApplications,
+             Cleanup
   end
 end

--- a/lib/pulsar/organizers/list.rb
+++ b/lib/pulsar/organizers/list.rb
@@ -3,6 +3,6 @@ module Pulsar
     include Interactor::Organizer
 
     organize IdentifyRepositoryLocation, IdentifyRepositoryType,
-             CloneRepository, AddApplications, Cleanup
+             CreateRunDirs, CloneRepository, AddApplications, Cleanup
   end
 end

--- a/pulsar.gemspec
+++ b/pulsar.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', '~> 3.2'
   gem.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   gem.add_development_dependency 'rubocop', '~> 0.47'
+  gem.add_development_dependency 'timecop', '~> 0.8'
 end

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -44,9 +44,21 @@ RSpec.describe 'Deploy' do
   end
 
   context 'when succeeds' do
+    subject { command }
+
     context 'deploys an application on a stage in the pulsar configuration' do
+      let(:output) { "blog deployed to production!\n" }
+
       context 'from a local folder' do
-        context 'leaves the tmp folder empty'
+        pending { is_expected.to eql(output) }
+
+        context 'leaves the tmp folder empty' do
+          subject { Dir.glob("#{Pulsar::PULSAR_TMP}/*") }
+
+          before { command }
+
+          it { is_expected.to be_empty }
+        end
       end
 
       context 'from a local repository' do

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Deploy' do
   subject { -> { command } }
 
   let(:command) do
-    `CAP_DRY_RUN=true ruby #{RSpec.configuration.pulsar_command} deploy #{options} #{arguments}`
+    `DRY_RUN=true ruby #{RSpec.configuration.pulsar_command} deploy #{options} #{arguments}`
   end
 
   let(:repo)      { RSpec.configuration.pulsar_conf_path }
@@ -133,8 +133,30 @@ RSpec.describe 'Deploy' do
   end
 
   context 'when fails' do
-    context 'because of wrong directory'
-    context 'because of empty directory'
-    context 'because Capistrano failed'
+    subject { command }
+
+    context 'because of wrong directory' do
+      let(:repo) { './some-wrong-directory' }
+
+      it { is_expected.to match("Failed to deploy blog on production.\n") }
+    end
+
+    context 'because of empty directory' do
+      let(:repo) { RSpec.configuration.pulsar_empty_conf_path }
+
+      it { is_expected.to match("Failed to deploy blog on production.\n") }
+    end
+
+    context 'because Bundler failed' do
+      let(:repo) { RSpec.configuration.pulsar_wrong_bundle_conf_path }
+
+      it { is_expected.to match("Failed to deploy blog on production.\n") }
+    end
+
+    context 'because Capistrano failed' do
+      let(:repo) { RSpec.configuration.pulsar_wrong_cap_conf_path }
+
+      it { is_expected.to match("Failed to deploy blog on production.\n") }
+    end
   end
 end

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Deploy' do
   subject { -> { command } }
 
   let(:command) do
-    `ruby #{RSpec.configuration.pulsar_command} deploy #{options} #{arguments}`
+    `CAP_DRY_RUN=true ruby #{RSpec.configuration.pulsar_command} deploy #{options} #{arguments}`
   end
 
   let(:repo)      { RSpec.configuration.pulsar_conf_path }

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe 'Deploy' do
     end
   end
 
-  context 'requires application and stage arguments' do
+  context 'requires application and environment arguments' do
     let(:arguments) { nil }
-    let(:error)     { /Usage: "pulsar deploy APPLICATION STAGE"/ }
+    let(:error)     { /Usage: "pulsar deploy APPLICATION ENVIRONMENT"/ }
 
     it { is_expected.to output(error).to_stderr_from_any_process }
   end
@@ -46,7 +46,7 @@ RSpec.describe 'Deploy' do
   context 'when succeeds' do
     subject { command }
 
-    context 'deploys an application on a stage in the pulsar configuration' do
+    context 'deploys an application on a environment in the pulsar configuration' do
       let(:output) { "blog deployed to production!\n" }
 
       context 'from a local folder' do

--- a/spec/features/list_spec.rb
+++ b/spec/features/list_spec.rb
@@ -128,13 +128,13 @@ RSpec.describe 'List' do
     context 'because of wrong directory' do
       let(:repo) { './some-wrong-directory' }
 
-      it { is_expected.to eql "Failed to list application and stages.\n" }
+      it { is_expected.to eql "Failed to list application and environments.\n" }
     end
 
     context 'because of empty directory' do
       let(:repo) { RSpec.configuration.pulsar_empty_conf_path }
 
-      it { is_expected.to eql "Failed to list application and stages.\n" }
+      it { is_expected.to eql "Failed to list application and environments.\n" }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'rspec'
 require 'stringio'
 require 'fileutils'
+require 'timecop'
 require 'codeclimate-test-reporter'
 require 'pulsar'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,8 @@ RSpec.configure do |config|
   config.add_setting :pulsar_command
   config.add_setting :pulsar_conf_path
   config.add_setting :pulsar_empty_conf_path
+  config.add_setting :pulsar_wrong_cap_conf_path
+  config.add_setting :pulsar_wrong_bundle_conf_path
   config.add_setting :pulsar_dotenv_conf_path
   config.add_setting :pulsar_local_conf_repo_path
   config.add_setting :pulsar_remote_git_conf
@@ -25,6 +27,8 @@ RSpec.configure do |config|
   config.pulsar_command = File.expand_path('./bin/pulsar')
   config.pulsar_conf_path = File.expand_path('./spec/support/dummies/conf/dir')
   config.pulsar_empty_conf_path = File.expand_path('./spec/support/dummies/conf/empty')
+  config.pulsar_wrong_cap_conf_path = File.expand_path('./spec/support/dummies/conf/wrong_cap')
+  config.pulsar_wrong_bundle_conf_path = File.expand_path('./spec/support/dummies/conf/wrong_bundle')
   config.pulsar_dotenv_conf_path = File.expand_path('./spec/support/dummies/conf/dotenv')
   config.pulsar_local_conf_repo_path = File.expand_path('./spec/support/tmp/dummy-repo')
   config.pulsar_remote_git_conf = 'git@github.com:nebulab/pulsar-conf-demo.git'

--- a/spec/support/dummies/conf/dir/Gemfile
+++ b/spec/support/dummies/conf/dir/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'capistrano'

--- a/spec/support/dummies/conf/dir/apps/Capfile
+++ b/spec/support/dummies/conf/dir/apps/Capfile
@@ -1,1 +1,9 @@
 # Defaults Capfile
+# Load DSL and set up stages
+require "capistrano/setup"
+
+# Include default deployment tasks
+require "capistrano/deploy"
+
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git

--- a/spec/support/dummies/conf/dir/apps/Capfile
+++ b/spec/support/dummies/conf/dir/apps/Capfile
@@ -1,0 +1,1 @@
+# Defaults Capfile

--- a/spec/support/dummies/conf/dir/apps/blog/Capfile
+++ b/spec/support/dummies/conf/dir/apps/blog/Capfile
@@ -1,0 +1,1 @@
+# App Defaults Capfile

--- a/spec/support/dummies/conf/dir/apps/blog/deploy.rb
+++ b/spec/support/dummies/conf/dir/apps/blog/deploy.rb
@@ -1,1 +1,4 @@
 # App Defaults deployrb
+
+set :application, 'blog'
+set :repo_url, 'git@example.com:me/blog.git'

--- a/spec/support/dummies/conf/dir/apps/blog/deploy.rb
+++ b/spec/support/dummies/conf/dir/apps/blog/deploy.rb
@@ -1,0 +1,1 @@
+# App Defaults deployrb

--- a/spec/support/dummies/conf/dir/apps/blog/production.rb
+++ b/spec/support/dummies/conf/dir/apps/blog/production.rb
@@ -1,0 +1,1 @@
+# Production config

--- a/spec/support/dummies/conf/dir/apps/blog/production.rb
+++ b/spec/support/dummies/conf/dir/apps/blog/production.rb
@@ -1,1 +1,4 @@
 # Production config
+
+server 'blog.com', user: 'deploy', roles: %w{web app db}, primary: true
+set :stage, :production

--- a/spec/support/dummies/conf/dir/apps/blog/staging.rb
+++ b/spec/support/dummies/conf/dir/apps/blog/staging.rb
@@ -1,1 +1,4 @@
 # Staging config
+
+server 'staging.blog.com', user: 'deploy', roles: %w{web app db}, primary: true
+set :stage, :staging

--- a/spec/support/dummies/conf/dir/apps/blog/staging.rb
+++ b/spec/support/dummies/conf/dir/apps/blog/staging.rb
@@ -1,0 +1,1 @@
+# Staging config

--- a/spec/support/dummies/conf/dir/apps/deploy.rb
+++ b/spec/support/dummies/conf/dir/apps/deploy.rb
@@ -1,0 +1,1 @@
+# Defaults deployrb

--- a/spec/support/dummies/conf/wrong_bundle/Gemfile
+++ b/spec/support/dummies/conf/wrong_bundle/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'this-gem-does-not-exist'

--- a/spec/support/dummies/conf/wrong_bundle/apps/Capfile
+++ b/spec/support/dummies/conf/wrong_bundle/apps/Capfile
@@ -1,0 +1,9 @@
+# Defaults Capfile
+# Load DSL and set up stages
+require "capistrano/setup"
+
+# Include default deployment tasks
+require "capistrano/deploy"
+
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git

--- a/spec/support/dummies/conf/wrong_bundle/apps/blog/Capfile
+++ b/spec/support/dummies/conf/wrong_bundle/apps/blog/Capfile
@@ -1,0 +1,1 @@
+# App Defaults Capfile

--- a/spec/support/dummies/conf/wrong_bundle/apps/blog/deploy.rb
+++ b/spec/support/dummies/conf/wrong_bundle/apps/blog/deploy.rb
@@ -1,0 +1,4 @@
+# App Defaults deployrb
+
+set :application, 'blog'
+set :repo_url, 'git@example.com:me/blog.git'

--- a/spec/support/dummies/conf/wrong_bundle/apps/blog/production.rb
+++ b/spec/support/dummies/conf/wrong_bundle/apps/blog/production.rb
@@ -1,0 +1,4 @@
+# Production config
+
+server 'blog.com', user: 'deploy', roles: %w{web app db}, primary: true
+set :stage, :production

--- a/spec/support/dummies/conf/wrong_bundle/apps/deploy.rb
+++ b/spec/support/dummies/conf/wrong_bundle/apps/deploy.rb
@@ -1,0 +1,1 @@
+# Defaults deployrb

--- a/spec/support/dummies/conf/wrong_cap/Gemfile
+++ b/spec/support/dummies/conf/wrong_cap/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'capistrano'

--- a/spec/support/dummies/conf/wrong_cap/apps/blog/deploy.rb
+++ b/spec/support/dummies/conf/wrong_cap/apps/blog/deploy.rb
@@ -1,0 +1,4 @@
+# App Defaults deployrb
+
+set :application, 'blog'
+set :repo_url, 'git@example.com:me/blog.git'

--- a/spec/support/dummies/conf/wrong_cap/apps/blog/production.rb
+++ b/spec/support/dummies/conf/wrong_cap/apps/blog/production.rb
@@ -1,0 +1,4 @@
+# Production config
+
+server 'blog.com', user: 'deploy', roles: %w{web app db}, primary: true
+set :stage, :production

--- a/spec/support/dummies/conf/wrong_cap/apps/deploy.rb
+++ b/spec/support/dummies/conf/wrong_cap/apps/deploy.rb
@@ -1,0 +1,1 @@
+# Defaults deployrb

--- a/spec/units/cli/deploy_spec.rb
+++ b/spec/units/cli/deploy_spec.rb
@@ -1,4 +1,116 @@
 require 'spec_helper'
 
 RSpec.describe Pulsar::CLI do
+  subject { Pulsar::Deploy }
+
+  let(:described_instance) { described_class.new }
+  let(:fail_text) { /Failed to deploy blog on production./ }
+
+  context '#deploy' do
+    let(:result) { spy }
+    let(:repo)   { './conf_repo' }
+
+    before do
+      allow($stdout).to receive(:puts)
+      allow(Pulsar::Deploy).to receive(:call).and_return(result)
+    end
+
+    context 'when using --conf-repo' do
+      before do
+        allow(described_instance)
+          .to receive(:options).and_return(conf_repo: repo)
+        described_instance.deploy('blog', 'production')
+      end
+
+      specify do
+        is_expected.to have_received(:call)
+          .with(repository: repo, application: 'blog', environment: 'production')
+      end
+
+      context 'success' do
+        subject { -> { described_instance.deploy('blog', 'production') } }
+
+        let(:success) { "Deployed blog on production!" }
+        let(:result) { spy(success?: true) }
+
+        it { is_expected.to output(/#{success}/).to_stdout }
+      end
+
+      context 'failure' do
+        subject { -> { described_instance.deploy('blog', 'production') } }
+
+        let(:result) { spy(success?: false) }
+
+        it { is_expected.to output(fail_text).to_stdout }
+      end
+    end
+
+    context 'when using configuration file' do
+      before do
+        allow(described_instance).to receive(:options).and_return({})
+        described_instance.deploy('blog', 'production')
+      end
+
+      around do |example|
+        old_const = Pulsar::PULSAR_CONF
+        Pulsar.send(:remove_const, 'PULSAR_CONF')
+        Pulsar::PULSAR_CONF = RSpec.configuration.pulsar_dotenv_conf_path
+        example.run
+        Pulsar.send(:remove_const, 'PULSAR_CONF')
+        Pulsar::PULSAR_CONF = old_const
+      end
+
+      specify do
+        is_expected.to have_received(:call)
+          .with(repository: repo, application: 'blog', environment: 'production')
+      end
+
+      context 'success' do
+        subject { -> { described_instance.deploy('blog', 'production') } }
+
+        let(:success) { "Deployed blog on production!" }
+        let(:result) { spy(success?: true) }
+
+        it { is_expected.to output(/#{success}/).to_stdout }
+      end
+
+      context 'failure' do
+        subject { -> { described_instance.deploy('blog', 'production') } }
+
+        let(:result) { spy(success?: false) }
+
+        it { is_expected.to output(fail_text).to_stdout }
+      end
+    end
+
+    context 'when using PULSAR_CONF_REPO' do
+      before do
+        allow(described_instance).to receive(:options).and_return({})
+        ENV['PULSAR_CONF_REPO'] = repo
+        described_instance.deploy('blog', 'production')
+      end
+
+      specify do
+        is_expected.to have_received(:call)
+          .with(repository: repo, application: 'blog', environment: 'production')
+      end
+
+      context 'success' do
+        subject { -> { described_instance.deploy('blog', 'production') } }
+
+        let(:success) { "Deployed blog on production!" }
+        let(:result) { spy(success?: true) }
+
+        it { is_expected.to output(/#{success}/).to_stdout }
+      end
+
+      context 'failure' do
+        subject { -> { described_instance.deploy('blog', 'production') } }
+
+        let(:result) { spy(success?: false) }
+
+        it { is_expected.to output(fail_text).to_stdout }
+      end
+    end
+  end
 end

--- a/spec/units/cli/list_spec.rb
+++ b/spec/units/cli/list_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Pulsar::CLI do
   subject { Pulsar::List }
 
   let(:described_instance) { described_class.new }
-  let(:fail_text) { /Failed to list application and stages./ }
+  let(:fail_text) { /Failed to list application and environments./ }
 
   context '#list' do
     let(:result) { spy }

--- a/spec/units/interactors/add_applications_spec.rb
+++ b/spec/units/interactors/add_applications_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Pulsar::AddApplications do
 
     before do
       allow(Dir).to receive(:[])
-        .and_return(%w(./blog/), %w(Capfile defaults.rb production.rb staging.rb))
+        .and_return(%w(./blog/), %w(Capfile deploy.rb production.rb staging.rb))
     end
 
     context 'success' do

--- a/spec/units/interactors/add_applications_spec.rb
+++ b/spec/units/interactors/add_applications_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Pulsar::AddApplications do
 
     before do
       allow(Dir).to receive(:[])
-        .and_return(%w(./blog/), %w(defaults.rb production.rb staging.rb))
+        .and_return(%w(./blog/), %w(Capfile defaults.rb production.rb staging.rb))
     end
 
     context 'success' do

--- a/spec/units/interactors/cleanup_spec.rb
+++ b/spec/units/interactors/cleanup_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe Pulsar::Cleanup do
   describe '.call' do
     subject { FileUtils }
 
-    let(:config_path) { './some-path' }
+    let(:run_path) { './some-path' }
 
     before do
       allow(subject).to receive(:rm_rf)
 
-      described_class.call(config_path: config_path)
+      described_class.call(run_path: run_path)
     end
 
-    it { is_expected.to have_received(:rm_rf).with(config_path) }
+    it { is_expected.to have_received(:rm_rf).with(run_path) }
   end
 end

--- a/spec/units/interactors/clone_repository_spec.rb
+++ b/spec/units/interactors/clone_repository_spec.rb
@@ -6,21 +6,20 @@ RSpec.describe Pulsar::CloneRepository do
   it { is_expected.to be_kind_of(Interactor) }
 
   describe '.call' do
-    subject { described_class.call(repository: repo, repository_type: type) }
+    subject do
+      described_class.call(config_path: run_path,
+                           repository: repo, repository_type: type)
+    end
 
     let(:repo) { './my-conf' }
+    let(:run_path) { "#{Pulsar::PULSAR_TMP}/run-#{Time.now.to_f}/conf" }
 
     context 'success' do
-      let(:tmp_path)   { Pulsar::PULSAR_TMP }
-      let(:tmp_config) { %r{#{tmp_path}\/conf-\d+\.\d+} }
-
-      before { expect(FileUtils).to receive(:mkdir_p).with(tmp_path).ordered }
-
       context 'when repository_type is :folder' do
         let(:type) { :folder }
 
         before do
-          expect(FileUtils).to receive(:cp_r).with(repo, tmp_config).ordered
+          expect(FileUtils).to receive(:cp_r).with("#{repo}/.", run_path).ordered
         end
 
         it { is_expected.to be_a_success }
@@ -28,10 +27,11 @@ RSpec.describe Pulsar::CloneRepository do
         context 'returns a config_path path' do
           subject do
             described_class
-              .call(repository: repo, repository_type: type).config_path
+              .call(config_path: run_path, repository: repo, repository_type: type)
+              .config_path
           end
 
-          it { is_expected.to match tmp_config }
+          it { is_expected.to match run_path }
         end
       end
 
@@ -40,7 +40,7 @@ RSpec.describe Pulsar::CloneRepository do
 
         before do
           expect(Rake).to receive(:sh)
-            .with(/git clone --quiet --depth 1 #{repo} #{tmp_config}/).ordered
+            .with(/git clone --quiet --depth 1 #{repo} #{run_path}/).ordered
         end
 
         it { is_expected.to be_a_success }
@@ -48,10 +48,11 @@ RSpec.describe Pulsar::CloneRepository do
         context 'returns a config_path path' do
           subject do
             described_class
-              .call(repository: repo, repository_type: type).config_path
+              .call(config_path: run_path, repository: repo, repository_type: type)
+              .config_path
           end
 
-          it { is_expected.to match tmp_config }
+          it { is_expected.to match run_path }
         end
       end
 
@@ -60,7 +61,7 @@ RSpec.describe Pulsar::CloneRepository do
         let(:repo) { 'github-account/my-conf' }
 
         let(:github_regex) do
-          /git clone --quiet --depth 1 git@github.com:#{repo}.git #{tmp_config}/
+          /git clone --quiet --depth 1 git@github.com:#{repo}.git #{run_path}/
         end
 
         before do
@@ -72,23 +73,36 @@ RSpec.describe Pulsar::CloneRepository do
         context 'returns a config_path path' do
           subject do
             described_class
-              .call(repository: repo, repository_type: type).config_path
+              .call(config_path: run_path, repository: repo, repository_type: type)
+              .config_path
           end
 
-          it { is_expected.to match tmp_config }
+          it { is_expected.to match run_path }
         end
       end
     end
 
     context 'failure' do
+      context 'when no config_path context is passed' do
+        subject do
+          described_class.call(repository: './some-path', repository_type: :something)
+        end
+
+        it { is_expected.to be_a_failure }
+      end
+
       context 'when no repository context is passed' do
-        subject { described_class.call(repository_type: :something) }
+        subject do
+          described_class.call(config_path: './some-path', repository_type: :something)
+        end
 
         it { is_expected.to be_a_failure }
       end
 
       context 'when no repository_type context is passed' do
-        subject { described_class.call(repository: './some-path') }
+        subject do
+          described_class.call(config_path: './some-path', repository: './some-path')
+        end
 
         it { is_expected.to be_a_failure }
       end
@@ -101,21 +115,5 @@ RSpec.describe Pulsar::CloneRepository do
         it { is_expected.to be_a_failure }
       end
     end
-  end
-
-  describe '.rollback' do
-    subject { FileUtils }
-
-    let(:config_path) { '~/.pulsar/tmp/config' }
-
-    before do
-      allow(subject).to receive(:rm_rf)
-      allow_any_instance_of(Interactor::Context)
-        .to receive(:config_path).and_return(config_path)
-
-      described_class.new.rollback
-    end
-
-    it { is_expected.to have_received(:rm_rf).with(config_path) }
   end
 end

--- a/spec/units/interactors/clone_repository_spec.rb
+++ b/spec/units/interactors/clone_repository_spec.rb
@@ -7,8 +7,11 @@ RSpec.describe Pulsar::CloneRepository do
 
   describe '.call' do
     subject do
-      described_class.call(config_path: run_path,
-                           repository: repo, repository_type: type)
+      described_class.call(
+        config_path: run_path,
+        repository: repo,
+        repository_type: type
+      )
     end
 
     let(:repo) { './my-conf' }

--- a/spec/units/interactors/create_capfile_spec.rb
+++ b/spec/units/interactors/create_capfile_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Pulsar::CreateCapfile do
             "Dir.glob(\"#{RSpec.configuration.pulsar_conf_path}/recipes/**/*.rake\").each { |r| import r }"
           end
 
-          it { is_expected.to match(/# Defaults Capfile\n# App Defaults Capfile/) }
+          it { is_expected.to match(/# Defaults Capfile.*# App Defaults Capfile/m) }
           it { is_expected.to include(load_recipes) }
         end
       end

--- a/spec/units/interactors/create_capfile_spec.rb
+++ b/spec/units/interactors/create_capfile_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+RSpec.describe Pulsar::CreateCapfile do
+  subject { described_class.new }
+
+  it { is_expected.to be_kind_of(Interactor) }
+
+  describe '.call' do
+    subject { command }
+
+    let(:command) { described_class.call(args) }
+    let(:args) do
+      {
+        config_path: RSpec.configuration.pulsar_conf_path,
+        application: 'blog', environment: 'production'
+      }
+    end
+
+    context 'success' do
+      it { is_expected.to be_a_success }
+
+      context 'creates a Capfile' do
+        subject { File }
+
+        it { is_expected.to exist(command.capistrano_path) }
+        it { is_expected.to exist(command.capfile_path) }
+
+        context 'with contents combined from pulsar configuration repo' do
+          subject { File.read(command.capfile_path) }
+
+          it { is_expected.to match(/# Defaults Capfile\n# App Defaults Capfile/) }
+          it { is_expected.to include("Dir.glob(\"**/*.rake\").each { |r| import r }") }
+        end
+      end
+    end
+
+    context 'failure' do
+      context 'when no config_path context is passed' do
+        subject { described_class.call }
+
+        it { is_expected.to be_a_failure }
+      end
+
+      context 'when no application context is passed' do
+        subject { described_class.call(config_path: './my-conf') }
+
+        it { is_expected.to be_a_failure }
+      end
+
+      context 'when no environment context is passed' do
+        subject { described_class.call(config_path: './my-conf', application: 'blog') }
+
+        it { is_expected.to be_a_failure }
+      end
+
+      context 'when an exception is triggered' do
+        before { allow(FileUtils).to receive(:mkdir_p).and_raise(RuntimeError) }
+
+        it { is_expected.to be_a_failure }
+      end
+    end
+  end
+end

--- a/spec/units/interactors/create_capfile_spec.rb
+++ b/spec/units/interactors/create_capfile_spec.rb
@@ -36,8 +36,12 @@ RSpec.describe Pulsar::CreateCapfile do
         context 'with contents combined from pulsar configuration repo' do
           subject { File.read(command.capfile_path) }
 
+          let(:load_recipes) do
+            "Dir.glob(\"#{RSpec.configuration.pulsar_conf_path}/recipes/**/*.rake\").each { |r| import r }"
+          end
+
           it { is_expected.to match(/# Defaults Capfile\n# App Defaults Capfile/) }
-          it { is_expected.to include("Dir.glob(\"**/*.rake\").each { |r| import r }") }
+          it { is_expected.to include(load_recipes) }
         end
       end
     end

--- a/spec/units/interactors/create_capfile_spec.rb
+++ b/spec/units/interactors/create_capfile_spec.rb
@@ -9,12 +9,15 @@ RSpec.describe Pulsar::CreateCapfile do
     subject { command }
 
     let(:command) { described_class.call(args) }
+    let(:cap_path) { "#{Pulsar::PULSAR_TMP}/cap-path" }
     let(:args) do
       {
         config_path: RSpec.configuration.pulsar_conf_path,
-        application: 'blog', environment: 'production'
+        cap_path: cap_path, application: 'blog', environment: 'production'
       }
     end
+
+    before { FileUtils.mkdir_p(cap_path) }
 
     context 'success' do
       it { is_expected.to be_a_success }
@@ -22,7 +25,6 @@ RSpec.describe Pulsar::CreateCapfile do
       context 'creates a Capfile' do
         subject { File }
 
-        it { is_expected.to exist(command.capistrano_path) }
         it { is_expected.to exist(command.capfile_path) }
 
         context 'with contents combined from pulsar configuration repo' do
@@ -53,8 +55,18 @@ RSpec.describe Pulsar::CreateCapfile do
         it { is_expected.to be_a_failure }
       end
 
+      context 'when no cap_path context is passed' do
+        subject do
+          described_class.call(
+            config_path: './my-conf', application: 'blog', environment: 'production'
+          )
+        end
+
+        it { is_expected.to be_a_failure }
+      end
+
       context 'when an exception is triggered' do
-        before { allow(FileUtils).to receive(:mkdir_p).and_raise(RuntimeError) }
+        before { allow(FileUtils).to receive(:touch).and_raise(RuntimeError) }
 
         it { is_expected.to be_a_failure }
       end

--- a/spec/units/interactors/create_capfile_spec.rb
+++ b/spec/units/interactors/create_capfile_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe Pulsar::CreateCapfile do
 
         it { is_expected.to exist(command.capfile_path) }
 
+        context 'with the required Capistrano path' do
+          subject { command.capfile_path }
+
+          it { is_expected.to eql "#{cap_path}/Capfile" }
+        end
+
         context 'with contents combined from pulsar configuration repo' do
           subject { File.read(command.capfile_path) }
 

--- a/spec/units/interactors/create_deploy_file_spec.rb
+++ b/spec/units/interactors/create_deploy_file_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Pulsar::CreateCapfile do
+RSpec.describe Pulsar::CreateDeployFile do
   subject { described_class.new }
 
   it { is_expected.to be_kind_of(Interactor) }
@@ -25,13 +25,12 @@ RSpec.describe Pulsar::CreateCapfile do
       context 'creates a Capfile' do
         subject { File }
 
-        it { is_expected.to exist(command.capfile_path) }
+        it { is_expected.to exist(command.deploy_file_path) }
 
         context 'with contents combined from pulsar configuration repo' do
-          subject { File.read(command.capfile_path) }
+          subject { File.read(command.deploy_file_path) }
 
-          it { is_expected.to match(/# Defaults Capfile\n# App Defaults Capfile/) }
-          it { is_expected.to include("Dir.glob(\"**/*.rake\").each { |r| import r }") }
+          it { is_expected.to match(/# Defaults deployrb\n# App Defaults deployrb/) }
         end
       end
     end

--- a/spec/units/interactors/create_run_dirs_spec.rb
+++ b/spec/units/interactors/create_run_dirs_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Pulsar::CreateRunDirs do
 
       let(:command) { described_class.call }
 
+      it { is_expected.to be_directory("#{Pulsar::PULSAR_HOME}/bundle") }
+      it { is_expected.to be_directory(command.bundle_path) }
       it { is_expected.to be_directory(command.run_path) }
       it { is_expected.to be_directory(command.config_path) }
       it { is_expected.to be_directory(command.cap_path) }

--- a/spec/units/interactors/create_run_dirs_spec.rb
+++ b/spec/units/interactors/create_run_dirs_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.describe Pulsar::CreateRunDirs do
+  subject { described_class.new }
+
+  it { is_expected.to be_kind_of(Interactor) }
+
+  describe '.success' do
+    around do |example|
+      Timecop.freeze { example.run }
+    end
+
+    context 'uses a timestamp' do
+      subject { described_class.call.timestamp }
+
+      it { is_expected.to eql Time.now.to_f }
+    end
+
+    context 'creates some folders' do
+      subject { File }
+
+      let(:command) { described_class.call }
+
+      it { is_expected.to be_directory(command.run_path) }
+      it { is_expected.to be_directory(command.config_path) }
+      it { is_expected.to be_directory(command.cap_path) }
+    end
+  end
+
+  describe '.rollback' do
+    subject { FileUtils }
+
+    let(:run_path) { '~/.pulsar/tmp/run' }
+
+    before do
+      allow(subject).to receive(:rm_rf)
+      allow_any_instance_of(Interactor::Context)
+        .to receive(:run_path).and_return(run_path)
+
+      described_class.new.rollback
+    end
+
+    it { is_expected.to have_received(:rm_rf).with(run_path) }
+  end
+end

--- a/spec/units/interactors/run_bundle_install_spec.rb
+++ b/spec/units/interactors/run_bundle_install_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe Pulsar::RunBundleInstall do
+  subject { described_class.new }
+
+  it { is_expected.to be_kind_of(Interactor) }
+
+  describe '.success' do
+    subject do
+      described_class.new(config_path: './config-path', bundle_path: './bundle-path')
+    end
+
+    let(:bundle_install_cmd) do
+      "BUNDLE_GEMFILE=./config-path/Gemfile BUNDLE_PATH=./bundle-path bundle install"
+    end
+
+    before do
+      allow(subject).to receive(:system)
+      subject.run
+    end
+
+    it { is_expected.to have_received(:system).with(bundle_install_cmd) }
+  end
+
+  context 'failure' do
+    context 'when no context is passed' do
+      subject { described_class.call }
+
+      it { is_expected.to be_a_failure }
+    end
+
+    context 'when no config_path context is passed' do
+      subject { described_class.call(bundle_path: './some-path') }
+
+      it { is_expected.to be_a_failure }
+    end
+
+    context 'when no bundle_path context is passed' do
+      subject { described_class.call(config_path: './some-path') }
+
+      it { is_expected.to be_a_failure }
+    end
+
+    context 'when an exception is triggered' do
+      subject do
+        described_class.new(config_path: './config-path', bundle_path: './bundle-path')
+      end
+
+      before do
+        allow(subject).to receive(:system).and_raise(RuntimeError)
+        subject.run
+      end
+
+      it { expect(subject.context).to be_a_failure }
+    end
+  end
+end

--- a/spec/units/interactors/run_capistrano_spec.rb
+++ b/spec/units/interactors/run_capistrano_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+RSpec.describe Pulsar::RunCapistrano do
+  subject { described_class.new }
+
+  it { is_expected.to be_kind_of(Interactor) }
+
+  describe '.success' do
+    subject do
+      described_class.new(
+        cap_path: RSpec.configuration.pulsar_conf_path, config_path: './config-path',
+        bundle_path: './bundle-path', environment: 'production'
+      )
+    end
+
+    let(:cap_cmd) { "cap production deploy" }
+    let(:bundle_cmd) do
+      "BUNDLE_GEMFILE=./config-path/Gemfile BUNDLE_PATH=./bundle-path bundle exec"
+    end
+
+    before do
+      allow(subject).to receive(:system)
+      subject.run
+    end
+
+    it { is_expected.to have_received(:system).with("#{bundle_cmd} #{cap_cmd}") }
+  end
+
+  context 'failure' do
+    context 'when no context is passed' do
+      subject { described_class.call }
+
+      it { is_expected.to be_a_failure }
+    end
+
+    context 'when no cap_path context is passed' do
+      subject do
+        described_class.call(
+          config_path: './config-path', bundle_path: './bundle-path',
+          environment: 'production'
+        )
+      end
+
+      it { is_expected.to be_a_failure }
+    end
+
+    context 'when no environment context is passed' do
+      subject do
+        described_class.call(
+          cap_path: './cap-path', config_path: './config-path',
+          bundle_path: './bundle-path'
+        )
+      end
+
+      it { is_expected.to be_a_failure }
+    end
+    context 'when no bundle_path context is passed' do
+      subject do
+        described_class.call(
+          cap_path: './cap-path', config_path: './config-path',
+          environment: 'production'
+        )
+      end
+
+      it { is_expected.to be_a_failure }
+    end
+
+    context 'when no config_path context is passed' do
+      subject do
+        described_class.call(
+          cap_path: './cap-path', environment: 'production',
+          bundle_path: './bundle-path'
+        )
+      end
+
+      it { is_expected.to be_a_failure }
+    end
+
+    context 'when an exception is triggered' do
+      subject do
+        described_class.call(
+          cap_path: './cap-path', config_path: './config-path',
+          bundle_path: './bundle-path', environment: 'production'
+        )
+      end
+
+      before { allow(Dir).to receive(:chdir).and_raise(RuntimeError) }
+
+      it { is_expected.to be_a_failure }
+    end
+  end
+end

--- a/spec/units/organizers/deploy_spec.rb
+++ b/spec/units/organizers/deploy_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Pulsar::Deploy do
       [
         Pulsar::IdentifyRepositoryLocation, Pulsar::IdentifyRepositoryType,
         Pulsar::CreateRunDirs, Pulsar::CloneRepository, Pulsar::CreateCapfile,
-        Pulsar::CreateDeployFile, Pulsar::Cleanup
+        Pulsar::CreateDeployFile, Pulsar::CopyEnvironmentFile, Pulsar::Cleanup
       ]
     end
 

--- a/spec/units/organizers/deploy_spec.rb
+++ b/spec/units/organizers/deploy_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Pulsar::Deploy do
     let(:interactors) do
       [
         Pulsar::IdentifyRepositoryLocation, Pulsar::IdentifyRepositoryType,
-        Pulsar::CloneRepository, Pulsar::CreateCapfile, Pulsar::Cleanup
+        Pulsar::CreateRunDirs, Pulsar::CloneRepository, Pulsar::CreateCapfile,
+        Pulsar::Cleanup
       ]
     end
 

--- a/spec/units/organizers/deploy_spec.rb
+++ b/spec/units/organizers/deploy_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe Pulsar::Deploy do
+  subject { described_class.new }
+
+  it { is_expected.to be_kind_of(Interactor::Organizer) }
+
+  context 'organizes interactors' do
+    subject { described_class.organized }
+
+    let(:interactors) do
+      [
+        Pulsar::IdentifyRepositoryLocation, Pulsar::IdentifyRepositoryType,
+        Pulsar::CloneRepository, Pulsar::CreateCapfile, Pulsar::Cleanup
+      ]
+    end
+
+    it { is_expected.to eql interactors }
+  end
+end

--- a/spec/units/organizers/deploy_spec.rb
+++ b/spec/units/organizers/deploy_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Pulsar::Deploy do
       [
         Pulsar::IdentifyRepositoryLocation, Pulsar::IdentifyRepositoryType,
         Pulsar::CreateRunDirs, Pulsar::CloneRepository, Pulsar::CreateCapfile,
-        Pulsar::CreateDeployFile, Pulsar::CopyEnvironmentFile, Pulsar::Cleanup
+        Pulsar::CreateDeployFile, Pulsar::CopyEnvironmentFile,
+        Pulsar::RunBundleInstall, Pulsar::RunCapistrano, Pulsar::Cleanup
       ]
     end
 

--- a/spec/units/organizers/deploy_spec.rb
+++ b/spec/units/organizers/deploy_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Pulsar::Deploy do
       [
         Pulsar::IdentifyRepositoryLocation, Pulsar::IdentifyRepositoryType,
         Pulsar::CreateRunDirs, Pulsar::CloneRepository, Pulsar::CreateCapfile,
-        Pulsar::Cleanup
+        Pulsar::CreateDeployFile, Pulsar::Cleanup
       ]
     end
 

--- a/spec/units/organizers/deploy_spec.rb
+++ b/spec/units/organizers/deploy_spec.rb
@@ -10,10 +10,16 @@ RSpec.describe Pulsar::Deploy do
 
     let(:interactors) do
       [
-        Pulsar::IdentifyRepositoryLocation, Pulsar::IdentifyRepositoryType,
-        Pulsar::CreateRunDirs, Pulsar::CloneRepository, Pulsar::CreateCapfile,
-        Pulsar::CreateDeployFile, Pulsar::CopyEnvironmentFile,
-        Pulsar::RunBundleInstall, Pulsar::RunCapistrano, Pulsar::Cleanup
+        Pulsar::IdentifyRepositoryLocation,
+        Pulsar::IdentifyRepositoryType,
+        Pulsar::CreateRunDirs,
+        Pulsar::CloneRepository,
+        Pulsar::CreateCapfile,
+        Pulsar::CreateDeployFile,
+        Pulsar::CopyEnvironmentFile,
+        Pulsar::RunBundleInstall,
+        Pulsar::RunCapistrano,
+        Pulsar::Cleanup
       ]
     end
 

--- a/spec/units/organizers/list_spec.rb
+++ b/spec/units/organizers/list_spec.rb
@@ -10,8 +10,11 @@ RSpec.describe Pulsar::List do
 
     let(:interactors) do
       [
-        Pulsar::IdentifyRepositoryLocation, Pulsar::IdentifyRepositoryType,
-        Pulsar::CreateRunDirs, Pulsar::CloneRepository, Pulsar::AddApplications,
+        Pulsar::IdentifyRepositoryLocation,
+        Pulsar::IdentifyRepositoryType,
+        Pulsar::CreateRunDirs,
+        Pulsar::CloneRepository,
+        Pulsar::AddApplications,
         Pulsar::Cleanup
       ]
     end

--- a/spec/units/organizers/list_spec.rb
+++ b/spec/units/organizers/list_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Pulsar::List do
     let(:interactors) do
       [
         Pulsar::IdentifyRepositoryLocation, Pulsar::IdentifyRepositoryType,
-        Pulsar::CloneRepository, Pulsar::AddApplications, Pulsar::Cleanup
+        Pulsar::CreateRunDirs, Pulsar::CloneRepository, Pulsar::AddApplications,
+        Pulsar::Cleanup
       ]
     end
 


### PR DESCRIPTION
This finally adds a rudimentary deploy command that creates a Capistrano 3 folder structure based on Pulsar configurations.

Specs are a little strange and incomplete because I still need to find a way to stub calls to the `cap` command.

The pulsar-conf repo is changed as well, the updated structure is on [nebulab/pulsar-conf-demo](https://github.com/nebulab/pulsar-conf-demo).

A README is also missing but we'll do that on a separate PR.