### PR TITLE
Fix reading config from non-git repo

### DIFF
--- a/lib/pulsar/interactors/identify_repository_type.rb
+++ b/lib/pulsar/interactors/identify_repository_type.rb
@@ -23,8 +23,9 @@ module Pulsar
     end
 
     def git_repository?
-      Rake.sh("git -C #{context.repository} status >/dev/null 2>&1") &&
-        File.exist?("#{context.repository}/.git")
+      git_status = "git -C #{context.repository} status >/dev/null 2>&1"
+
+      Rake.sh(git_status) { |status, _| status }
     end
 
     def github_repository?

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe 'Deploy' do
       let(:output) { "Deployed blog on production!\n" }
 
       context 'from a local folder' do
+        let(:repo) { Dir.mktmpdir }
+
+        before do
+          FileUtils.cp_r("#{RSpec.configuration.pulsar_conf_path}/.", repo)
+        end
+
         it { is_expected.to match(output) }
 
         context 'leaves the tmp folder empty' do

--- a/spec/features/list_spec.rb
+++ b/spec/features/list_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe 'List' do
       let(:output) { "blog: production, staging\necommerce: staging\n" }
 
       context 'from a local folder' do
+        let(:repo) { Dir.mktmpdir }
+
+        before do
+          FileUtils.cp_r("#{RSpec.configuration.pulsar_conf_path}/.", repo)
+        end
+
         it { is_expected.to eql(output) }
 
         context 'leaves the tmp folder empty' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'rspec'
 require 'stringio'
 require 'fileutils'
 require 'timecop'
+require 'tmpdir'
 require 'codeclimate-test-reporter'
 require 'pulsar'
 

--- a/spec/units/interactors/identify_repository_type_spec.rb
+++ b/spec/units/interactors/identify_repository_type_spec.rb
@@ -31,10 +31,7 @@ RSpec.describe Pulsar::IdentifyRepositoryType do
           end
 
           context 'is a git repository' do
-            before do
-              allow(Rake).to receive(:sh).and_return(true)
-              allow(File).to receive(:exist?).and_return(true)
-            end
+            before { allow(Rake).to receive(:sh).and_return(true) }
 
             it { is_expected.to eql :git }
           end


### PR DESCRIPTION
There was a bug reading configuration from a folder that is not a git
repo. This should fix it.

I've also added specs to a tempfolder to make sure it doesn't conflict
with the pulsar source repo (that's why I didn't see the problem before).