### PR TITLE
Improve exceptions handling and reporting

### DIFF
--- a/lib/pulsar/cli.rb
+++ b/lib/pulsar/cli.rb
@@ -17,6 +17,7 @@ module Pulsar
         puts 'Successfully created intial repo!'
       else
         puts 'Failed to create intial repo.'
+        puts result.error.message
       end
     end
 
@@ -34,6 +35,7 @@ module Pulsar
         puts result.applications
       else
         puts 'Failed to list application and environments.'
+        puts result.error.message
       end
     end
 
@@ -55,6 +57,7 @@ module Pulsar
         puts "Deployed #{application} on #{environment}!"
       else
         puts "Failed to deploy #{application} on #{environment}."
+        puts result.error.message
       end
     end
 

--- a/lib/pulsar/interactors/add_applications.rb
+++ b/lib/pulsar/interactors/add_applications.rb
@@ -10,7 +10,7 @@ module Pulsar
         context.applications << "#{File.basename(app)}: #{stages_for(app)}"
       end
     rescue
-      context.fail!
+      context.fail! error: $!
     end
 
     private

--- a/lib/pulsar/interactors/clone_repository.rb
+++ b/lib/pulsar/interactors/clone_repository.rb
@@ -11,7 +11,7 @@ module Pulsar
       when :folder then copy_local_folder
       end
     rescue
-      context.fail!
+      context.fail! error: $!
     end
 
     private

--- a/lib/pulsar/interactors/copy_environment_file.rb
+++ b/lib/pulsar/interactors/copy_environment_file.rb
@@ -10,7 +10,7 @@ module Pulsar
       FileUtils.mkdir_p(context.cap_deploy_path)
       FileUtils.cp(env_file, context.environment_file_path)
     rescue
-      context.fail!
+      context.fail! error: $!
     end
 
     private

--- a/lib/pulsar/interactors/copy_initial_repository.rb
+++ b/lib/pulsar/interactors/copy_initial_repository.rb
@@ -10,7 +10,7 @@ module Pulsar
 
       FileUtils.cp_r(File.expand_path(initial_repo), context.directory)
     rescue
-      context.fail!
+      context.fail! error: $!
     end
 
     private

--- a/lib/pulsar/interactors/create_capfile.rb
+++ b/lib/pulsar/interactors/create_capfile.rb
@@ -14,7 +14,7 @@ module Pulsar
       Rake.sh("cat #{app_capfile}     >> #{context.capfile_path}") if File.exist?(app_capfile)
       Rake.sh("echo '#{import_tasks}' >> #{context.capfile_path}")
     rescue
-      context.fail!
+      context.fail! error: $!
     end
 
     private

--- a/lib/pulsar/interactors/create_deploy_file.rb
+++ b/lib/pulsar/interactors/create_deploy_file.rb
@@ -13,7 +13,7 @@ module Pulsar
       Rake.sh("cat #{default_deploy} >> #{context.deploy_file_path}") if File.exist?(default_deploy)
       Rake.sh("cat #{app_deploy}     >> #{context.deploy_file_path}") if File.exist?(app_deploy)
     rescue
-      context.fail!
+      context.fail! error: $!
     end
 
     private

--- a/lib/pulsar/interactors/identify_repository_location.rb
+++ b/lib/pulsar/interactors/identify_repository_location.rb
@@ -11,7 +11,7 @@ module Pulsar
                                       :remote
                                     end
     rescue
-      context.fail!
+      context.fail! error: $!
     end
 
     private

--- a/lib/pulsar/interactors/identify_repository_type.rb
+++ b/lib/pulsar/interactors/identify_repository_type.rb
@@ -12,7 +12,7 @@ module Pulsar
         context.repository_type = github_repository? ? :github : :git
       end
     rescue
-      context.fail!
+      context.fail! error: $!
     end
 
     private

--- a/lib/pulsar/interactors/run_bundle_install.rb
+++ b/lib/pulsar/interactors/run_bundle_install.rb
@@ -15,7 +15,7 @@ module Pulsar
         context.fail! unless system("#{bundle_cmd}#{out_redir}")
       end
     rescue
-      context.fail!
+      context.fail! error: $!
     end
 
     private

--- a/lib/pulsar/interactors/run_capistrano.rb
+++ b/lib/pulsar/interactors/run_capistrano.rb
@@ -15,7 +15,7 @@ module Pulsar
         context.fail! unless system("#{gemfile_env} #{bundle_env} #{cap_cmd}#{out_redir}")
       end
     rescue
-      context.fail!
+      context.fail! error: $!
     end
 
     private

--- a/spec/features/install_spec.rb
+++ b/spec/features/install_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Install' do
   context 'when fails' do
     let(:arguments) { '/pulsar-conf' }
 
-    it { is_expected.to eql "Failed to create intial repo.\n" }
+    it { is_expected.to match "Failed to create intial repo.\n" }
 
     context 'does not create a directory' do
       subject { -> { command } }

--- a/spec/features/list_spec.rb
+++ b/spec/features/list_spec.rb
@@ -134,13 +134,15 @@ RSpec.describe 'List' do
     context 'because of wrong directory' do
       let(:repo) { './some-wrong-directory' }
 
-      it { is_expected.to eql "Failed to list application and environments.\n" }
+      it { is_expected.to match "Failed to list application and environments.\n" }
+      it { is_expected.to match "Repository ./some-wrong-directory does not exists.\n" }
     end
 
     context 'because of empty directory' do
       let(:repo) { RSpec.configuration.pulsar_empty_conf_path }
 
-      it { is_expected.to eql "Failed to list application and environments.\n" }
+      it { is_expected.to match "Failed to list application and environments.\n" }
+      it { is_expected.to match "No valid pulsar repository found at #{RSpec.configuration.pulsar_empty_conf_path}.\n" }
     end
   end
 end


### PR DESCRIPTION
Bisogna definire le eccezioni che vale la pena gestire separatamente. Proposte:

+ è bene discriminare tra repo inesistenti (così da dare un feedback immediato nel caso si sia sbagliato a digitare il nome del repo), da quelli invalidi.

Non so per quale motivo ma `$!.message` ritorna un output troncato a 81 caratteri quando l'errore contiene un comandi di shell eseguiti via `Rake.sh`