### PR TITLE
Remove local git repository support

### DIFF
--- a/lib/pulsar/interactors/identify_repository_type.rb
+++ b/lib/pulsar/interactors/identify_repository_type.rb
@@ -7,12 +7,10 @@ module Pulsar
     def call
       case context.repository_location
       when :local
-        context.repository_type = git_repository? ? :git : :folder
+        context.repository_type = :folder
       when :remote
         context.repository_type = github_repository? ? :github : :git
       end
-    rescue
-      context.fail!
     end
 
     private
@@ -20,12 +18,6 @@ module Pulsar
     def validate_input!
       context.fail! if context.repository.nil?
       context.fail! if context.repository_location.nil?
-    end
-
-    def git_repository?
-      git_status = "git -C #{context.repository} status >/dev/null 2>&1"
-
-      Rake.sh(git_status) { |status, _| status }
     end
 
     def github_repository?

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -67,43 +67,6 @@ RSpec.describe 'Deploy' do
         end
       end
 
-      context 'from a local repository' do
-        let(:repo) { RSpec.configuration.pulsar_local_conf_repo_path }
-
-        before do
-          FileUtils.cp_r(RSpec.configuration.pulsar_conf_path, repo)
-          `git init #{repo}`
-        end
-
-        context 'uncommitted changes' do
-          it { is_expected.not_to match(output) }
-
-          context 'leaves the tmp folder empty' do
-            subject { Dir.glob("#{Pulsar::PULSAR_TMP}/*") }
-
-            before { command }
-
-            it { is_expected.to be_empty }
-          end
-        end
-
-        context 'committed changes' do
-          before do
-            `git -C #{repo} add . && git -C #{repo} commit -m 'Initial Commit'`
-          end
-
-          it { is_expected.to match(output) }
-
-          context 'leaves the tmp folder empty' do
-            subject { Dir.glob("#{Pulsar::PULSAR_TMP}/*") }
-
-            before { command }
-
-            it { is_expected.to be_empty }
-          end
-        end
-      end
-
       context 'from a remote Git repository' do
         let(:repo)      { RSpec.configuration.pulsar_remote_git_conf }
         let(:arguments) { 'your_app staging' }

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Deploy' do
   subject { -> { command } }
 
   let(:command) do
-    `DRY_RUN=true ruby #{RSpec.configuration.pulsar_command} deploy #{options} #{arguments}`
+    `DRY_RUN=true #{RSpec.configuration.pulsar_command} deploy #{options} #{arguments}`
   end
 
   let(:repo)      { RSpec.configuration.pulsar_conf_path }

--- a/spec/features/install_spec.rb
+++ b/spec/features/install_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Install' do
   subject { command }
 
   let(:command) do
-    `ruby #{RSpec.configuration.pulsar_command} install #{arguments}`
+    `#{RSpec.configuration.pulsar_command} install #{arguments}`
   end
 
   let(:arguments) { nil }

--- a/spec/features/list_spec.rb
+++ b/spec/features/list_spec.rb
@@ -59,43 +59,6 @@ RSpec.describe 'List' do
         end
       end
 
-      context 'from a local repository' do
-        let(:repo) { RSpec.configuration.pulsar_local_conf_repo_path }
-
-        before do
-          FileUtils.cp_r(RSpec.configuration.pulsar_conf_path, repo)
-          `git init #{repo}`
-        end
-
-        context 'uncommitted changes' do
-          it { is_expected.not_to eql(output) }
-
-          context 'leaves the tmp folder empty' do
-            subject { Dir.glob("#{Pulsar::PULSAR_TMP}/*") }
-
-            before { command }
-
-            it { is_expected.to be_empty }
-          end
-        end
-
-        context 'committed changes' do
-          before do
-            `git -C #{repo} add . && git -C #{repo} commit -m 'Initial Commit'`
-          end
-
-          it { is_expected.to eql(output) }
-
-          context 'leaves the tmp folder empty' do
-            subject { Dir.glob("#{Pulsar::PULSAR_TMP}/*") }
-
-            before { command }
-
-            it { is_expected.to be_empty }
-          end
-        end
-      end
-
       context 'from a remote Git repository' do
         let(:repo)   { RSpec.configuration.pulsar_remote_git_conf }
         let(:output) { "your_app: production, staging\n" }

--- a/spec/features/list_spec.rb
+++ b/spec/features/list_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'List' do
   subject { -> { command } }
 
   let(:command) do
-    `ruby #{RSpec.configuration.pulsar_command} list #{arguments}`
+    `#{RSpec.configuration.pulsar_command} list #{arguments}`
   end
 
   let(:repo)      { RSpec.configuration.pulsar_conf_path }

--- a/spec/features/version_spec.rb
+++ b/spec/features/version_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Version' do
   subject { command }
 
   let(:command) do
-    `ruby #{RSpec.configuration.pulsar_command} #{arguments}`
+    `#{RSpec.configuration.pulsar_command} #{arguments}`
   end
 
   let(:arguments) { "--version" }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ RSpec.configure do |config|
   config.add_setting :pulsar_remote_git_conf
   config.add_setting :pulsar_remote_github_conf
 
-  config.pulsar_command = File.expand_path('./exe/pulsar')
+  config.pulsar_command = "ruby -Ilib #{File.expand_path('./exe/pulsar')}"
   config.pulsar_conf_path = File.expand_path('./spec/support/dummies/conf/dir')
   config.pulsar_empty_conf_path = File.expand_path('./spec/support/dummies/conf/empty')
   config.pulsar_wrong_cap_conf_path = File.expand_path('./spec/support/dummies/conf/wrong_cap')

--- a/spec/units/interactors/identify_repository_type_spec.rb
+++ b/spec/units/interactors/identify_repository_type_spec.rb
@@ -14,26 +14,13 @@ RSpec.describe Pulsar::IdentifyRepositoryType do
 
     context 'success' do
       context 'when local' do
-        before do
-          expect(Rake)
-            .to receive(:sh).with("git -C #{repo} status >/dev/null 2>&1")
-        end
-
         it { is_expected.to be_a_success }
 
         context 'the configuration repository' do
           subject { described_class.call(args).repository_type }
 
           context 'is a folder' do
-            before { allow(Rake).to receive(:sh).and_return(false) }
-
             it { is_expected.to eql :folder }
-          end
-
-          context 'is a git repository' do
-            before { allow(Rake).to receive(:sh).and_return(true) }
-
-            it { is_expected.to eql :git }
           end
         end
       end
@@ -68,12 +55,6 @@ RSpec.describe Pulsar::IdentifyRepositoryType do
 
       context 'when no repository_location context is passed' do
         subject { described_class.call(repository: repo) }
-
-        it { is_expected.to be_a_failure }
-      end
-
-      context 'when an exception is triggered' do
-        before { allow(Rake).to receive(:sh).and_raise(RuntimeError) }
 
         it { is_expected.to be_a_failure }
       end


### PR DESCRIPTION
This is just useless... let's remove it!

For some reason I thought this was a good idea somehow. From now on everything that's local should be treated as a local folder.

Git repos will only be available remotely (either GitHub path or full git path).