### PR TITLE
Only run coverage on the most recent ruby build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -64,4 +64,4 @@ test:
     - rvm-exec 2.1.10 bash -c "bundle exec rspec --color --format documentation spec"
     - rvm-exec 2.2.6 bash -c "bundle exec rspec --color --format documentation spec"
     - rvm-exec 2.3.3 bash -c "bundle exec rspec --color --format documentation spec"
-    - rvm-exec 2.4.0 bash -c "bundle exec rspec --color --format documentation spec"
+    - rvm-exec 2.4.0 bash -c "COVERAGE=true bundle exec rspec --color --format documentation spec"

--- a/lib/pulsar/cli.rb
+++ b/lib/pulsar/cli.rb
@@ -1,4 +1,4 @@
-if ENV['TEST']
+if ENV['COVERAGE']
   ENV['FEATURE_TESTS'] = 'true'
   require_relative '../../spec/support/coverage_setup'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-ENV['TEST'] = 'true'
-
 require 'support/coverage_setup'
 require 'rspec'
 require 'stringio'

--- a/spec/support/coverage_setup.rb
+++ b/spec/support/coverage_setup.rb
@@ -29,9 +29,11 @@ if ENV['FEATURE_TESTS']
   end
 end
 
-SimpleCov.start do
-  add_group 'Interactors', 'lib/pulsar/interactors'
-  add_group 'Organizers', 'lib/pulsar/organizers'
+if ENV['COVERAGE']
+  SimpleCov.start do
+    add_group 'Interactors', 'lib/pulsar/interactors'
+    add_group 'Organizers', 'lib/pulsar/organizers'
 
-  add_filter 'spec/*'
+    add_filter 'spec/*'
+  end
 end


### PR DESCRIPTION
This is needed so that Coveralls won't merge multiple simplecov lines and show a higher hit per line of code.