### PR TITLE
Check for permissions before opening Dotenv file

### DIFF
--- a/lib/pulsar/cli.rb
+++ b/lib/pulsar/cli.rb
@@ -95,6 +95,8 @@ module Pulsar
     private
 
     def load_config
+      return unless File.exist?(PULSAR_CONF) && File.stat(PULSAR_CONF).readable?
+
       Dotenv.load(PULSAR_CONF) # Load configurations for Pulsar
     end
 

--- a/spec/units/cli/deploy_spec.rb
+++ b/spec/units/cli/deploy_spec.rb
@@ -46,8 +46,10 @@ RSpec.describe Pulsar::CLI do
     end
 
     context 'when using configuration file' do
+      let(:options) { {} }
+
       before do
-        allow(described_instance).to receive(:options).and_return({})
+        allow(described_instance).to receive(:options).and_return(options)
         described_instance.deploy('blog', 'production')
       end
 
@@ -72,6 +74,18 @@ RSpec.describe Pulsar::CLI do
         let(:result) { spy(success?: true) }
 
         it { is_expected.to output(/#{success}/).to_stdout }
+
+        context 'when file is unaccessible' do
+          let(:options) { { conf_repo: repo } }
+
+          around do |example|
+            system("chmod 000 #{RSpec.configuration.pulsar_dotenv_conf_path}")
+            example.run
+            system("chmod 644 #{RSpec.configuration.pulsar_dotenv_conf_path}")
+          end
+
+          it { is_expected.to output(/#{success}/).to_stdout }
+        end
       end
 
       context 'failure' do

--- a/spec/units/cli/list_spec.rb
+++ b/spec/units/cli/list_spec.rb
@@ -43,8 +43,10 @@ RSpec.describe Pulsar::CLI do
     end
 
     context 'when using configuration file' do
+      let(:options) { {} }
+
       before do
-        allow(described_instance).to receive(:options).and_return({})
+        allow(described_instance).to receive(:options).and_return(options)
         described_instance.list
       end
 
@@ -66,6 +68,18 @@ RSpec.describe Pulsar::CLI do
         let(:result) { spy(success?: true, applications: applications) }
 
         it { is_expected.to output(/blog: staging/).to_stdout }
+
+        context 'when file is unaccessible' do
+          let(:options) { { conf_repo: repo } }
+
+          around do |example|
+            system("chmod 000 #{RSpec.configuration.pulsar_dotenv_conf_path}")
+            example.run
+            system("chmod 644 #{RSpec.configuration.pulsar_dotenv_conf_path}")
+          end
+
+          it { is_expected.to output(/blog: staging/).to_stdout }
+        end
       end
 
       context 'failure' do

--- a/spec/units/cli/task_spec.rb
+++ b/spec/units/cli/task_spec.rb
@@ -46,8 +46,10 @@ RSpec.describe Pulsar::CLI do
     end
 
     context 'when using configuration file' do
+      let(:options) { {} }
+
       before do
-        allow(described_instance).to receive(:options).and_return({})
+        allow(described_instance).to receive(:options).and_return(options)
         described_instance.task('blog', 'production', 'deploy:check')
       end
 
@@ -72,6 +74,18 @@ RSpec.describe Pulsar::CLI do
         let(:result) { spy(success?: true) }
 
         it { is_expected.to output(/#{success}/).to_stdout }
+
+        context 'when file is unaccessible' do
+          let(:options) { { conf_repo: repo } }
+
+          around do |example|
+            system("chmod 000 #{RSpec.configuration.pulsar_dotenv_conf_path}")
+            example.run
+            system("chmod 644 #{RSpec.configuration.pulsar_dotenv_conf_path}")
+          end
+
+          it { is_expected.to output(/#{success}/).to_stdout }
+        end
       end
 
       context 'failure' do


### PR DESCRIPTION
This is necessary because otherwise it will end up failing the run even
if everything is passed on the command line and there's some .env file
not readable.

With this it should make the run by skipping Dotenv altogether.

This closes #53 